### PR TITLE
fix: daemon resource thresholds incompatible with macOS (upstream #1078)

### DIFF
--- a/v3/@claude-flow/cli/src/commands/daemon.ts
+++ b/v3/@claude-flow/cli/src/commands/daemon.ts
@@ -214,7 +214,7 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean): Promi
   // This prevents command injection via paths
   const child = spawn(process.execPath, [
     cliPath,
-    'daemon', 'start', '--foreground', '--quiet'
+    'daemon', 'start', '--foreground'
   ], {
     cwd: resolvedRoot,
     detached: true,


### PR DESCRIPTION
## Replica upstream
Questa PR ricrea nel fork la fix upstream:
- Upstream PR: https://github.com/ruvnet/claude-flow/pull/1078
- Upstream issue correlata: https://github.com/ruvnet/claude-flow/issues/1077

## Contenuto
- Correzione soglie risorse daemon incompatibili con macOS
- Soglia CPU resa core-aware invece di valore fisso troppo basso
- `minFreeMemoryPercent` resa compatibile con semantica `os.freemem()` su macOS
- Rimosso `--quiet` hardcoded nello spawn background per miglior diagnosi

## Metodo
Cherry-pick del commit upstream `f95a4d55af3172c03219c8212873aca60e893c27` (con `-x`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted resource thresholds for improved macOS compatibility
  * CPU load checking now uses dynamic, core-aware thresholds
  * Daemon startup messages now visible in logs for better debugging
  * Enhanced error messages to display resource threshold values when limits are exceeded

<!-- end of auto-generated comment: release notes by coderabbit.ai -->