### PR TITLE
fix: hook commands fail - stdin JSON not parsed (upstream #1061)

### DIFF
--- a/v3/@claude-flow/cli/.claude/hooks/hook-bridge.sh
+++ b/v3/@claude-flow/cli/.claude/hooks/hook-bridge.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# hook-bridge.sh - Bridges Claude Code hooks (stdin JSON) to claude-flow CLI
+#
+# Claude Code passes hook context as JSON via stdin, NOT as shell environment
+# variables. This script reads the stdin JSON, extracts the relevant fields
+# using jq, and forwards them as proper CLI arguments.
+#
+# Usage: hook-bridge.sh <mode>
+#
+# Requires: jq (https://jqlang.github.io/jq/)
+
+MODE="${1:-}"
+
+# Read JSON from stdin (Claude Code always pipes hook data this way)
+INPUT=$(cat 2>/dev/null) || INPUT='{}'
+[ -z "$INPUT" ] && INPUT='{}'
+
+# Safe JSON field extraction - returns empty string on missing/null fields
+jf() {
+  echo "$INPUT" | jq -r "$1" 2>/dev/null | grep -v '^null$' || echo ""
+}
+
+case "$MODE" in
+  # -- PreToolUse hooks -----------------------------------------------
+  pre-edit)
+    FILE=$(jf '.tool_input.file_path')
+    [ -z "$FILE" ] && exit 0
+    exec npx @claude-flow/cli@latest hooks pre-edit --file "$FILE"
+    ;;
+
+  pre-command)
+    CMD=$(jf '.tool_input.command')
+    [ -z "$CMD" ] && exit 0
+    exec npx @claude-flow/cli@latest hooks pre-command --command "$CMD"
+    ;;
+
+  pre-task)
+    DESC=$(jf '.tool_input.prompt // .tool_input.description')
+    [ -z "$DESC" ] && exit 0
+    exec npx @claude-flow/cli@latest hooks pre-task --description "$DESC"
+    ;;
+
+  # -- PostToolUse hooks ----------------------------------------------
+  post-edit)
+    FILE=$(jf '.tool_input.file_path')
+    [ -z "$FILE" ] && exit 0
+    exec npx @claude-flow/cli@latest hooks post-edit --file "$FILE" --success true
+    ;;
+
+  post-command)
+    CMD=$(jf '.tool_input.command')
+    [ -z "$CMD" ] && exit 0
+    exec npx @claude-flow/cli@latest hooks post-command --command "$CMD" --success true
+    ;;
+
+  post-task)
+    AGENT_ID=$(jf '.tool_input.description // .tool_input.prompt')
+    [ -z "$AGENT_ID" ] && AGENT_ID="unknown"
+    exec npx @claude-flow/cli@latest hooks post-task --task-id "$AGENT_ID" --success true
+    ;;
+
+  # -- UserPromptSubmit -----------------------------------------------
+  route)
+    PROMPT=$(jf '.prompt')
+    [ -z "$PROMPT" ] && exit 0
+    exec npx @claude-flow/cli@latest hooks route --task "$PROMPT"
+    ;;
+
+  # -- SessionStart ---------------------------------------------------
+  daemon-start)
+    exec npx @claude-flow/cli@latest daemon start --quiet
+    ;;
+
+  session-restore)
+    SID=$(jf '.session_id')
+    if [ -n "$SID" ]; then
+      exec npx @claude-flow/cli@latest hooks session-restore --session-id "$SID"
+    else
+      exec npx @claude-flow/cli@latest hooks session-restore --latest
+    fi
+    ;;
+
+  # -- Stop -----------------------------------------------------------
+  stop-check)
+    echo '{"ok":true}'
+    exit 0
+    ;;
+
+  # -- Notification ---------------------------------------------------
+  notify)
+    MSG=$(jf '.message // .notification_message // .content')
+    [ -z "$MSG" ] && exit 0
+    exec npx @claude-flow/cli@latest memory store --namespace notifications --key "notify" --value "$MSG"
+    ;;
+
+  *)
+    echo "Unknown hook mode: $MODE" >&2
+    exit 1
+    ;;
+esac

--- a/v3/@claude-flow/cli/.claude/settings.json
+++ b/v3/@claude-flow/cli/.claude/settings.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TOOL_INPUT_file_path\" ] && npx @claude-flow/cli@latest hooks pre-edit --file \"$TOOL_INPUT_file_path\" 2>/dev/null || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh pre-edit",
+            "timeout": 10000,
             "continueOnError": true
           }
         ]
@@ -17,8 +17,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TOOL_INPUT_command\" ] && npx @claude-flow/cli@latest hooks pre-command --command \"$TOOL_INPUT_command\" 2>/dev/null || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh pre-command",
+            "timeout": 10000,
             "continueOnError": true
           }
         ]
@@ -28,8 +28,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TOOL_INPUT_prompt\" ] && npx @claude-flow/cli@latest hooks pre-task --task-id \"task-$(date +%s)\" --description \"$TOOL_INPUT_prompt\" 2>/dev/null || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh pre-task",
+            "timeout": 10000,
             "continueOnError": true
           }
         ]
@@ -41,8 +41,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TOOL_INPUT_file_path\" ] && npx @claude-flow/cli@latest hooks post-edit --file \"$TOOL_INPUT_file_path\" --success \"${TOOL_SUCCESS:-true}\" 2>/dev/null || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh post-edit",
+            "timeout": 10000,
             "continueOnError": true
           }
         ]
@@ -52,8 +52,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TOOL_INPUT_command\" ] && npx @claude-flow/cli@latest hooks post-command --command \"$TOOL_INPUT_command\" --success \"${TOOL_SUCCESS:-true}\" 2>/dev/null || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh post-command",
+            "timeout": 10000,
             "continueOnError": true
           }
         ]
@@ -63,8 +63,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$TOOL_RESULT_agent_id\" ] && npx @claude-flow/cli@latest hooks post-task --task-id \"$TOOL_RESULT_agent_id\" --success \"${TOOL_SUCCESS:-true}\" 2>/dev/null || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh post-task",
+            "timeout": 10000,
             "continueOnError": true
           }
         ]
@@ -75,8 +75,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$PROMPT\" ] && npx @claude-flow/cli@latest hooks route --task \"$PROMPT\" || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh route",
+            "timeout": 10000,
             "continueOnError": true
           }
         ]
@@ -87,14 +87,14 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx @claude-flow/cli@latest daemon start --quiet 2>/dev/null || true",
-            "timeout": 5000,
+            "command": ".claude/hooks/hook-bridge.sh daemon-start",
+            "timeout": 10000,
             "continueOnError": true
           },
           {
             "type": "command",
-            "command": "[ -n \"$SESSION_ID\" ] && npx @claude-flow/cli@latest hooks session-restore --session-id \"$SESSION_ID\" 2>/dev/null || true",
-            "timeout": 10000,
+            "command": ".claude/hooks/hook-bridge.sh session-restore",
+            "timeout": 15000,
             "continueOnError": true
           }
         ]
@@ -105,7 +105,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '{\"ok\": true}'",
+            "command": ".claude/hooks/hook-bridge.sh stop-check",
             "timeout": 1000
           }
         ]
@@ -116,8 +116,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$NOTIFICATION_MESSAGE\" ] && npx @claude-flow/cli@latest memory store --namespace notifications --key \"notify-$(date +%s)\" --value \"$NOTIFICATION_MESSAGE\" 2>/dev/null || true",
-            "timeout": 3000,
+            "command": ".claude/hooks/hook-bridge.sh notify",
+            "timeout": 5000,
             "continueOnError": true
           }
         ]


### PR DESCRIPTION
## Replica upstream
Questa PR ricrea nel fork la fix upstream:
- Upstream PR: https://github.com/ruvnet/claude-flow/pull/1061
- Issue correlate: https://github.com/ruvnet/claude-flow/issues/1084 e https://github.com/ruvnet/claude-flow/issues/947

## Contenuto
- Introduce `.claude/hooks/hook-bridge.sh`
- Converte il passaggio dati hook da env vars a parsing JSON stdin (comportamento reale di Claude Code)
- Aggiorna generator/template init per usare il bridge in tutte le hook command rilevanti

## Metodo
Cherry-pick del commit upstream `f8d16a4d48622f215bda1824e5977008f921e0e5` (con `-x`).

## Nota operativa
Il bridge usa `jq`; verificare presenza di `jq` negli ambienti target.
