### PR TITLE
fix(workers): cleanup background processes and avoid default background fan-out

### DIFF
--- a/v3/@claude-flow/cli/__tests__/services/headless-worker-executor.cleanup.test.ts
+++ b/v3/@claude-flow/cli/__tests__/services/headless-worker-executor.cleanup.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
+import type { Mock } from 'vitest';
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+  execSync: vi.fn(),
+}));
+
+import { HeadlessWorkerExecutor } from '../../src/services/headless-worker-executor.js';
+
+interface MockChildProcess extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: Mock;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+}
+
+function createMockChildProcess(
+  onKill?: (signal: NodeJS.Signals, proc: MockChildProcess) => void
+): MockChildProcess {
+  const proc = new EventEmitter() as MockChildProcess;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.exitCode = null;
+  proc.signalCode = null;
+  proc.kill = vi.fn((signal: NodeJS.Signals) => {
+    onKill?.(signal, proc);
+    return true;
+  }) as Mock;
+  return proc;
+}
+
+describe('HeadlessWorkerExecutor process cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should escalate to SIGKILL after timeout grace period', async () => {
+    const child = createMockChildProcess((signal, proc) => {
+      if (signal === 'SIGKILL') {
+        proc.signalCode = 'SIGKILL';
+        setImmediate(() => proc.emit('close', null));
+      }
+    });
+    (spawn as Mock).mockReturnValue(child);
+
+    const executor = new HeadlessWorkerExecutor(process.cwd(), { killGraceMs: 10 });
+
+    const result = await (executor as any).executeClaudeCode('timeout-test', {
+      sandbox: 'strict',
+      model: 'sonnet',
+      timeoutMs: 20,
+      executionId: 'exec-timeout',
+      workerType: 'audit',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Execution timed out');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(executor.getActiveCount()).toBe(0);
+  });
+
+  it('should keep cancelled execution tracked until process closes', async () => {
+    const child = createMockChildProcess((signal, proc) => {
+      if (signal === 'SIGTERM') {
+        setTimeout(() => {
+          proc.signalCode = 'SIGTERM';
+          proc.emit('close', null);
+        }, 5);
+      }
+    });
+    (spawn as Mock).mockReturnValue(child);
+
+    const executor = new HeadlessWorkerExecutor(process.cwd(), { killGraceMs: 10 });
+
+    const resultPromise = (executor as any).executeClaudeCode('cancel-test', {
+      sandbox: 'strict',
+      model: 'sonnet',
+      timeoutMs: 1000,
+      executionId: 'exec-cancel',
+      workerType: 'audit',
+    });
+
+    expect(executor.getActiveCount()).toBe(1);
+    expect(executor.cancel('exec-cancel')).toBe(true);
+    expect(executor.getActiveCount()).toBe(1);
+
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Execution cancelled');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(executor.getActiveCount()).toBe(0);
+  });
+});

--- a/v3/@claude-flow/cli/src/init/claudemd-generator.ts
+++ b/v3/@claude-flow/cli/src/init/claudemd-generator.ts
@@ -106,18 +106,18 @@ function autoStartProtocol(): string {
 
 ### Auto-Start Swarm Protocol
 
-When the user requests a complex task, spawn agents in background and WAIT:
+When the user requests a complex task, spawn agents in one message and WAIT:
 
 \`\`\`javascript
 // STEP 1: Initialize swarm coordination
 Bash("npx @claude-flow/cli@latest swarm init --topology hierarchical --max-agents 8 --strategy specialized")
 
-// STEP 2: Spawn ALL agents IN BACKGROUND in a SINGLE message
-Task({prompt: "Research requirements...", subagent_type: "researcher", run_in_background: true})
-Task({prompt: "Design architecture...", subagent_type: "system-architect", run_in_background: true})
-Task({prompt: "Implement solution...", subagent_type: "coder", run_in_background: true})
-Task({prompt: "Write tests...", subagent_type: "tester", run_in_background: true})
-Task({prompt: "Review code quality...", subagent_type: "reviewer", run_in_background: true})
+// STEP 2: Spawn ALL agents in a SINGLE message (background only if needed)
+Task({prompt: "Research requirements...", subagent_type: "researcher"})
+Task({prompt: "Design architecture...", subagent_type: "system-architect"})
+Task({prompt: "Implement solution...", subagent_type: "coder"})
+Task({prompt: "Write tests...", subagent_type: "tester"})
+Task({prompt: "Review code quality...", subagent_type: "reviewer"})
 \`\`\`
 
 ### Agent Routing
@@ -139,10 +139,11 @@ Task({prompt: "Review code quality...", subagent_type: "reviewer", run_in_backgr
 function executionRules(): string {
   return `## Swarm Execution Rules
 
-- ALWAYS use \`run_in_background: true\` for all agent Task calls
+- Use \`run_in_background: true\` only for independent long-running tasks
 - ALWAYS put ALL agent Task calls in ONE message for parallel execution
 - After spawning, STOP — do NOT add more tool calls or check status
 - Never poll TaskOutput or check swarm status — trust agents to return
+- Never exceed configured \`max-agents\` with background task fan-out
 - When agent results arrive, review ALL results before proceeding`;
 }
 

--- a/v3/plugins/teammate-plugin/src/mcp-tools.ts
+++ b/v3/plugins/teammate-plugin/src/mcp-tools.ts
@@ -161,6 +161,10 @@ export const TEAMMATE_MCP_TOOLS: MCPTool[] = [
           type: 'boolean',
           description: 'Can this teammate delegate to others',
         },
+        runInBackground: {
+          type: 'boolean',
+          description: 'Run teammate task in background (default: false)',
+        },
       },
       required: ['teamName', 'name', 'role', 'prompt'],
     },
@@ -585,7 +589,8 @@ export async function handleMCPTool(
           allowedTools,
           mode: params.mode as TeammateSpawnConfig['mode'],
           delegateAuthority: params.delegateAuthority as boolean,
-          runInBackground: true,
+          runInBackground:
+            typeof params.runInBackground === 'boolean' ? params.runInBackground : false,
         };
         const teammate = await bridge.spawnTeammate(spawnConfig);
         const agentInput = bridge.buildAgentInput(spawnConfig);

--- a/v3/plugins/teammate-plugin/src/teammate-bridge.ts
+++ b/v3/plugins/teammate-plugin/src/teammate-bridge.ts
@@ -1060,7 +1060,7 @@ export class TeammateBridge extends EventEmitter {
       team_name: config.teamName ?? process.env.CLAUDE_CODE_TEAM_NAME,
       allowed_tools: config.allowedTools,
       mode: config.mode,
-      run_in_background: config.runInBackground ?? true,
+      run_in_background: config.runInBackground ?? false,
       max_turns: config.maxTurns,
     };
   }

--- a/v3/plugins/teammate-plugin/tests/mcp-tools.test.ts
+++ b/v3/plugins/teammate-plugin/tests/mcp-tools.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { TeammateBridge } from '../src/teammate-bridge.js';
+import { handleMCPTool, TEAMMATE_MCP_TOOLS } from '../src/mcp-tools.js';
+
+describe('MCP tools - teammate_spawn', () => {
+  let spawnTeammate: ReturnType<typeof vi.fn>;
+  let buildAgentInput: ReturnType<typeof vi.fn>;
+  let bridge: TeammateBridge;
+
+  beforeEach(() => {
+    spawnTeammate = vi.fn().mockResolvedValue({
+      id: 'teammate-1',
+      name: 'dev-1',
+      role: 'coder',
+      status: 'active',
+      spawnedAt: new Date(),
+      messagesSent: 0,
+      messagesReceived: 0,
+    });
+
+    buildAgentInput = vi.fn((config: { runInBackground?: boolean; name: string; role: string; prompt: string }) => ({
+      description: `${config.role}: ${config.name}`,
+      prompt: config.prompt,
+      subagent_type: config.role,
+      run_in_background: config.runInBackground ?? false,
+    }));
+
+    bridge = {
+      spawnTeammate,
+      buildAgentInput,
+    } as unknown as TeammateBridge;
+  });
+
+  it('should default runInBackground=false when omitted', async () => {
+    const result = await handleMCPTool(bridge, 'teammate_spawn', {
+      teamName: 'team-1',
+      name: 'dev-1',
+      role: 'coder',
+      prompt: 'Implement the feature',
+    });
+
+    expect(result.success).toBe(true);
+    expect(spawnTeammate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runInBackground: false,
+      })
+    );
+    expect((result.data as any).agentInput.run_in_background).toBe(false);
+  });
+
+  it('should pass runInBackground=true when explicitly requested', async () => {
+    const result = await handleMCPTool(bridge, 'teammate_spawn', {
+      teamName: 'team-1',
+      name: 'dev-1',
+      role: 'coder',
+      prompt: 'Implement the feature',
+      runInBackground: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(spawnTeammate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runInBackground: true,
+      })
+    );
+    expect((result.data as any).agentInput.run_in_background).toBe(true);
+  });
+
+  it('should expose runInBackground in teammate_spawn schema', () => {
+    const teammateSpawnTool = TEAMMATE_MCP_TOOLS.find((tool) => tool.name === 'teammate_spawn');
+    expect(teammateSpawnTool).toBeDefined();
+    expect((teammateSpawnTool?.inputSchema.properties as any).runInBackground).toEqual(
+      expect.objectContaining({
+        type: 'boolean',
+      })
+    );
+  });
+});

--- a/v3/plugins/teammate-plugin/tests/teammate-bridge.test.ts
+++ b/v3/plugins/teammate-plugin/tests/teammate-bridge.test.ts
@@ -241,6 +241,19 @@ describe('Teammate Spawning', () => {
     expect(agentInput.team_name).toBe('spawn-test-team');
     expect(agentInput.allowed_tools).toEqual(['Read', 'Grep']);
     expect(agentInput.mode).toBe('plan');
+    expect(agentInput.run_in_background).toBe(false);
+  });
+
+  it('should preserve explicit runInBackground=true in AgentInput', async () => {
+    const agentInput = bridge.buildAgentInput({
+      name: 'reviewer-bg',
+      role: 'reviewer',
+      prompt: 'Review code in background',
+      teamName: 'spawn-test-team',
+      runInBackground: true,
+    });
+
+    expect(agentInput.run_in_background).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- fix headless worker timeout/cancel cleanup so child processes stay tracked until exit
- add SIGTERM -> SIGKILL escalation with configurable grace period (`killGraceMs`)
- prevent forced background teammate execution by default (`runInBackground` now defaults to `false`)
- expose optional `runInBackground` in `teammate_spawn` MCP input schema
- soften generated CLAUDE.md swarm guidance to avoid always-on background fan-out
- add targeted regression tests for process cleanup + teammate MCP/background defaults

## Validation
- `cd v3/plugins/teammate-plugin && npm test`
- `cd v3/plugins/teammate-plugin && npm run build`
- `cd v3/@claude-flow/cli && npm test -- __tests__/services/headless-worker-executor.cleanup.test.ts __tests__/services/headless-worker-executor.test.ts`
- `cd v3/@claude-flow/cli && npx tsc --noEmit --pretty false --module NodeNext --target ES2022 --moduleResolution NodeNext src/services/headless-worker-executor.ts`

## References
- Closes #8
- Upstream issue: https://github.com/ruvnet/claude-flow/issues/1042


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced process cleanup and termination workflow with graceful shutdown and configurable grace period.
  * Optimized agent spawning to use single-message parallel execution model.

* **Behavior Changes**
  * Background task execution default changed from automatic to opt-in (disabled by default).

* **Tests**
  * Added test coverage for process termination and agent spawning flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->