### PR TITLE
fix(teammate): guard general-purpose subagent on legacy claude code

### DIFF
--- a/v3/plugins/teammate-plugin/tests/teammate-bridge.test.ts
+++ b/v3/plugins/teammate-plugin/tests/teammate-bridge.test.ts
@@ -244,6 +244,18 @@ describe('Teammate Spawning', () => {
     expect(agentInput.run_in_background).toBe(false);
   });
 
+  it('should remap general-purpose subagent type on legacy Claude Code', async () => {
+    const agentInput = bridge.buildAgentInput({
+      name: 'worker-1',
+      role: 'general-purpose',
+      prompt: 'Handle generic tasks',
+      teamName: 'spawn-test-team',
+    });
+
+    expect(agentInput.subagent_type).toBe('researcher');
+    expect(agentInput.description).toBe('general-purpose: worker-1');
+  });
+
   it('should preserve explicit runInBackground=true in AgentInput', async () => {
     const agentInput = bridge.buildAgentInput({
       name: 'reviewer-bg',


### PR DESCRIPTION
## Summary
- add a centralized guard in teammate bridge when building Task AgentInput
- remap `subagent_type=general-purpose` to `researcher` for Claude Code versions older than 2.1.34
- keep behavior unchanged for other roles and newer versions
- add regression test for legacy-version remapping

## Context
- Fixes #3
- Related upstream: ruvnet/claude-flow#1075

## Validation
- `npm test -- tests/teammate-bridge.test.ts`
- `npm test`
