### PR TITLE
fix(hooks): fallback to hook payload when TOOL_INPUT vars are missing

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-command-stdin.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-command-stdin.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { hooksCommand } from '../src/commands/hooks.js';
+import type { CommandContext } from '../src/types.js';
+import { callMCPTool } from '../src/mcp-client.js';
+
+vi.mock('../src/mcp-client.js', () => ({
+  callMCPTool: vi.fn(),
+  MCPClientError: class MCPClientError extends Error {
+    constructor(message: string, public toolName: string, public cause?: Error) {
+      super(message);
+      this.name = 'MCPClientError';
+    }
+  },
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: {
+    writeln: vi.fn(),
+    printInfo: vi.fn(),
+    printSuccess: vi.fn(),
+    printError: vi.fn(),
+    printWarning: vi.fn(),
+    printTable: vi.fn(),
+    printJson: vi.fn(),
+    printList: vi.fn(),
+    printBox: vi.fn(),
+    createSpinner: vi.fn(() => ({
+      start: vi.fn(),
+      succeed: vi.fn(),
+      fail: vi.fn(),
+      stop: vi.fn(),
+    })),
+    highlight: (str: string) => str,
+    bold: (str: string) => str,
+    dim: (str: string) => str,
+    success: (str: string) => str,
+    error: (str: string) => str,
+    warning: (str: string) => str,
+    info: (str: string) => str,
+    progressBar: () => '[=====>    ]',
+    setColorEnabled: vi.fn(),
+  },
+}));
+
+vi.mock('../src/prompt.js', () => ({
+  select: vi.fn(),
+  confirm: vi.fn(),
+  input: vi.fn(),
+}));
+
+describe('hooks command hook-input fallback', () => {
+  const mockedCallMCPTool = vi.mocked(callMCPTool);
+
+  beforeEach(() => {
+    mockedCallMCPTool.mockReset();
+    mockedCallMCPTool.mockImplementation(async (toolName: string) => {
+      if (toolName === 'hooks_pre-edit') {
+        return {
+          filePath: 'src/new.ts',
+          operation: 'create',
+          context: {
+            fileExists: false,
+            fileType: '.ts',
+            relatedFiles: [],
+            suggestedAgents: [],
+            patterns: [],
+            risks: [],
+          },
+          recommendations: [],
+        };
+      }
+
+      if (toolName === 'hooks_post-edit') {
+        return {
+          filePath: 'src/edit.ts',
+          success: false,
+          recorded: true,
+          learningUpdates: {
+            patternsUpdated: 1,
+            confidenceAdjusted: 1,
+            newPatterns: 0,
+          },
+        };
+      }
+
+      return {};
+    });
+  });
+
+  it('uses hook payload json for pre-edit when file flag is empty', async () => {
+    const preEdit = hooksCommand.subcommands?.find(cmd => cmd.name === 'pre-edit');
+    expect(preEdit).toBeDefined();
+
+    const ctx: CommandContext = {
+      args: [],
+      flags: {
+        _: [],
+        format: 'json',
+        hookInputJson: JSON.stringify({
+          tool_name: 'Write',
+          tool_input: { file_path: 'src/new.ts' },
+        }),
+      },
+      cwd: process.cwd(),
+      interactive: false,
+    };
+
+    const result = await preEdit!.action!(ctx);
+
+    expect(result?.success).toBe(true);
+    expect(mockedCallMCPTool).toHaveBeenCalledWith(
+      'hooks_pre-edit',
+      expect.objectContaining({
+        filePath: 'src/new.ts',
+        operation: 'create',
+      })
+    );
+  });
+
+  it('uses hook payload json for post-edit success and file when flags are empty', async () => {
+    const postEdit = hooksCommand.subcommands?.find(cmd => cmd.name === 'post-edit');
+    expect(postEdit).toBeDefined();
+
+    const ctx: CommandContext = {
+      args: [],
+      flags: {
+        _: [],
+        format: 'json',
+        hookInputJson: JSON.stringify({
+          tool_input: { file_path: 'src/edit.ts' },
+          tool_success: false,
+        }),
+      },
+      cwd: process.cwd(),
+      interactive: false,
+    };
+
+    const result = await postEdit!.action!(ctx);
+
+    expect(result?.success).toBe(true);
+    expect(mockedCallMCPTool).toHaveBeenCalledWith(
+      'hooks_post-edit',
+      expect.objectContaining({
+        filePath: 'src/edit.ts',
+        success: false,
+      })
+    );
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/settings-generator.test.ts
+++ b/v3/@claude-flow/cli/__tests__/settings-generator.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { generateSettings } from '../src/init/settings-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+function getEditHookCommand(settings: Record<string, unknown>, event: 'PreToolUse' | 'PostToolUse'): string {
+  const hooks = settings.hooks as Record<string, Array<{ hooks: Array<{ command: string }> }>>;
+  const eventHooks = hooks[event];
+  return eventHooks[0].hooks[0].command;
+}
+
+describe('settings-generator hooks commands', () => {
+  it('uses direct pre-edit command without file-path shell guard', () => {
+    const settings = generateSettings({ ...DEFAULT_INIT_OPTIONS }) as Record<string, unknown>;
+    const command = getEditHookCommand(settings, 'PreToolUse');
+
+    expect(command).toContain('hooks pre-edit --file "$TOOL_INPUT_file_path"');
+    expect(command).not.toContain('[ -n "$TOOL_INPUT_file_path" ] &&');
+  });
+
+  it('uses direct post-edit command without file-path shell guard', () => {
+    const settings = generateSettings({ ...DEFAULT_INIT_OPTIONS }) as Record<string, unknown>;
+    const command = getEditHookCommand(settings, 'PostToolUse');
+
+    expect(command).toContain('hooks post-edit --file "$TOOL_INPUT_file_path"');
+    expect(command).not.toContain('[ -n "$TOOL_INPUT_file_path" ] &&');
+  });
+});

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -156,7 +156,7 @@ function generateHooksConfig(config: HooksConfig): object {
         hooks: [
           {
             type: 'command',
-            command: '[ -n "$TOOL_INPUT_file_path" ] && npx @claude-flow/cli@latest hooks pre-edit --file "$TOOL_INPUT_file_path" 2>/dev/null || true',
+            command: 'npx @claude-flow/cli@latest hooks pre-edit --file "$TOOL_INPUT_file_path" 2>/dev/null || true',
             timeout: config.timeout,
             continueOnError: true,
           },
@@ -198,7 +198,7 @@ function generateHooksConfig(config: HooksConfig): object {
         hooks: [
           {
             type: 'command',
-            command: '[ -n "$TOOL_INPUT_file_path" ] && npx @claude-flow/cli@latest hooks post-edit --file "$TOOL_INPUT_file_path" --success "${TOOL_SUCCESS:-true}" 2>/dev/null || true',
+            command: 'npx @claude-flow/cli@latest hooks post-edit --file "$TOOL_INPUT_file_path" --success "${TOOL_SUCCESS:-true}" 2>/dev/null || true',
             timeout: config.timeout,
             continueOnError: true,
           },


### PR DESCRIPTION
## Summary
- make `hooks pre-edit` and `hooks post-edit` resilient when `TOOL_INPUT_*` env vars are empty by falling back to official Claude Code hook payload JSON
- add support for reading hook payload from stdin (and from `--hook-input-json` for deterministic testing)
- infer `operation=create` for pre-edit when hook payload reports `tool_name=Write`
- update generated `.claude/settings.json` hook commands to always invoke edit hooks (remove shell guard that skipped execution when env var was empty)
- add regression tests for settings generation and hook-payload fallback behavior

## Context
- Fixes #1
- Related upstream: ruvnet/claude-flow#1084

## Validation
- `npm test -- __tests__/hooks-command-stdin.test.ts __tests__/settings-generator.test.ts`
- `npm test` *(fails in this workspace for pre-existing package-resolution issues in unrelated suites)*
