### PR TITLE
chore(ci): fix rollback-manager CLI smoke path

### DIFF
--- a/.github/workflows/rollback-manager.yml
+++ b/.github/workflows/rollback-manager.yml
@@ -448,9 +448,9 @@ jobs:
         run: |
           echo "🖥️ Verifying CLI functionality..."
           
-          # Test basic CLI commands
-          node dist/cli/main.js --version || (echo "❌ CLI verification failed" && exit 1)
-          node dist/cli/main.js --help > /dev/null || (echo "❌ CLI help failed" && exit 1)
+          # Test basic CLI commands via the repository's actual CLI entrypoint
+          node ./v3/@claude-flow/cli/bin/cli.js --version || (echo "❌ CLI verification failed" && exit 1)
+          node ./v3/@claude-flow/cli/bin/cli.js --help > /dev/null || (echo "❌ CLI help failed" && exit 1)
           
           echo "✅ CLI verification passed"
 


### PR DESCRIPTION
## Summary
- fix rollback workflow post-verification CLI smoke path:
  - from `node dist/cli/main.js ...` (missing)
  - to `node ./v3/@claude-flow/cli/bin/cli.js ...` (actual repo entrypoint)
- keep rollback smoke gate behavior unchanged (still fails if CLI smoke checks fail)

## Why
Issue #16 flagged a broken CLI path in `rollback-manager.yml` and stale smoke verification wiring.

## Validation
- `rg` check confirms rollback workflow no longer references `dist/cli/main.js`
- workflow command resolution check confirms all `npm run` calls in rollback-manager map to existing root scripts

## Context
- Fixes #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-rollback verification procedure to reference the correct CLI entrypoint path
  * Refined formatting in the manual rollback approval workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->