### PR TITLE
chore(root): deprecate broken root entrypoint contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ npm run test:integration:plugin
 
 ## Known Limitations
 
+- Root package import entrypoint is deprecated; use CLI (`npx claude-flow`) or package-level imports (for example `@claude-flow/cli`).
 - `v3/@claude-flow/cli/bin/*.js` imports `../dist/src/*`; `dist` is not committed by default.
 - Root workflow compatibility scripts are lightweight wrappers and may no-op when package-level suites are unavailable.
 - Some command outputs are demonstrative rather than telemetry-backed (for example provider usage tables).

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+const message =
+  'The root "claude-flow" package entrypoint is deprecated and does not expose a runtime API. Use the CLI with `npx claude-flow` or import from `@claude-flow/cli`.';
+
+throw new Error(message);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "claude-flow",
   "version": "3.1.0-alpha.1",
   "description": "Enterprise AI agent orchestration for Claude Code - Deploy 60+ specialized agents in coordinated swarms with self-learning, fault-tolerant consensus, vector memory, and MCP integration",
-  "main": "dist/index.js",
+  "main": "./index.js",
   "type": "module",
   "bin": {
     "claude-flow": "./v3/@claude-flow/cli/bin/cli.js"
@@ -38,7 +38,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "echo \"Root dev entrypoint is deprecated. Use: npm run dev:cli\"",
+    "dev:cli": "cd v3/@claude-flow/cli && npm run build -- --watch",
     "build": "tsc",
     "build:ts": "cd v3/@claude-flow/cli && npm run build || true",
     "typecheck": "npm run build:ts",
@@ -49,6 +50,7 @@
     "test:performance": "echo \"No root performance suite configured\"",
     "test:benchmark": "npm run test:performance",
     "test:coverage": "npm run test -- --coverage",
+    "test:root-entrypoints": "node ./scripts/verify-root-entrypoints.mjs",
     "test:ui": "vitest --ui",
     "test:security": "vitest run v3/__tests__/security/",
     "lint": "cd v3/@claude-flow/cli && npm run lint || true",

--- a/scripts/verify-root-entrypoints.mjs
+++ b/scripts/verify-root-entrypoints.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '..');
+const packageJsonPath = path.join(repoRoot, 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+const failures = [];
+
+if (typeof packageJson.main !== 'string' || packageJson.main.length === 0) {
+  failures.push('package.json main field is missing.');
+} else {
+  const mainPath = path.resolve(repoRoot, packageJson.main);
+  if (!fs.existsSync(mainPath)) {
+    failures.push(`package.json main points to a missing path: ${packageJson.main}`);
+  }
+}
+
+const devScript = packageJson.scripts?.dev;
+if (typeof devScript !== 'string' || devScript.length === 0) {
+  failures.push('package.json scripts.dev is missing.');
+} else if (devScript.includes('src/index.ts')) {
+  failures.push('scripts.dev still points to missing src/index.ts.');
+}
+
+if (failures.length > 0) {
+  console.error('Root entrypoint contract verification failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Root entrypoint contract verification passed.');


### PR DESCRIPTION
## Summary
- replace broken root `main` target (`dist/index.js`) with an explicit deprecation entrypoint (`./index.js`)
- deprecate broken root `dev` script (`tsx watch src/index.ts`) and provide supported replacement (`dev:cli`)
- add root contract smoke check script: `npm run test:root-entrypoints`
- document root entrypoint deprecation in README

## Why
Issue #19 flagged a broken root entrypoint contract (`main` + `dev`) pointing to missing paths. This change makes the contract explicit and verifiable.

## Validation
- `npm run test:root-entrypoints`
- `npm run dev`
- `node -e "import('./index.js').catch((err) => { console.log(err.message); })"`

## Context
- Fixes #19
