### PR TITLE
chore(ci): fix stale publish command in v3-ci

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -152,6 +152,6 @@ jobs:
 
       - name: Publish alpha
         working-directory: v3
-        run: pnpm publish:alpha
+        run: pnpm publish:v3alpha
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- replace stale `pnpm publish:alpha` call in V3 CI workflow with existing script `pnpm publish:v3alpha`
- preserve existing v3alpha publish tag semantics

## Validation
- confirmed `.github/workflows/v3-ci.yml` now calls `publish:v3alpha`
- confirmed `v3/package.json` defines `publish:v3alpha`

## Context
- Fixes #15
