### PR TITLE
test(docker): enforce strict MCP regression assertions

### DIFF
--- a/tests/docker-regression/docker-compose.yml
+++ b/tests/docker-regression/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - CLAUDE_FLOW_EMBEDDING_DIM=384
       - CI=true
       - TEST_REPORT_PATH=/app/reports
-      - MCP_SERVER_HOST=localhost
+      - MCP_SERVER_HOST=mcp-server
       - MCP_SERVER_PORT=3000
     networks:
       - claude-flow-test
@@ -57,7 +57,7 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
-    command: ["npx", "claude-flow", "mcp", "start", "--port", "3000"]
+    command: ["npx", "claude-flow", "mcp", "start", "--transport", "http", "--host", "0.0.0.0", "--port", "3000"]
 
   # Unit test runner
   unit-tests:

--- a/tests/docker-regression/scripts/test-mcp-server.sh
+++ b/tests/docker-regression/scripts/test-mcp-server.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Claude-Flow MCP Server Test Suite
-# Tests MCP server functionality and tools
+# Strict MCP connectivity and JSON-RPC behavior checks
 
-set -e
+set -euo pipefail
 
 echo "=== MCP SERVER TEST SUITE ==="
 echo ""
@@ -14,12 +14,12 @@ TOTAL=0
 MCP_HOST="${MCP_SERVER_HOST:-localhost}"
 MCP_PORT="${MCP_SERVER_PORT:-3000}"
 MCP_URL="http://${MCP_HOST}:${MCP_PORT}"
+RPC_URL="${MCP_URL}/rpc"
+INVALID_MCP_URL="http://127.0.0.1:65530"
 
-# Helper function
 run_test() {
     local test_name="$1"
     local command="$2"
-    local expected_exit="${3:-0}"
 
     TOTAL=$((TOTAL + 1))
     echo -n "  Testing: ${test_name}... "
@@ -29,16 +29,44 @@ run_test() {
     exit_code=$?
     set -e
 
-    if [ "$exit_code" -eq "$expected_exit" ]; then
+    if [ "$exit_code" -eq 0 ]; then
         echo "✓ PASSED"
         PASSED=$((PASSED + 1))
-        return 0
     else
         echo "✗ FAILED (exit: $exit_code)"
         echo "    Output: ${output:0:200}"
         FAILED=$((FAILED + 1))
-        return 1
     fi
+}
+
+run_negative_test() {
+    local test_name="$1"
+    local command="$2"
+
+    TOTAL=$((TOTAL + 1))
+    echo -n "  Testing: ${test_name}... "
+
+    set +e
+    output=$(eval "$command" 2>&1)
+    exit_code=$?
+    set -e
+
+    if [ "$exit_code" -ne 0 ]; then
+        echo "✓ PASSED"
+        PASSED=$((PASSED + 1))
+    else
+        echo "✗ FAILED (expected non-zero exit)"
+        echo "    Output: ${output:0:200}"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+json_rpc() {
+    local payload="$1"
+    curl -fsS --max-time 5 \
+      -H 'Content-Type: application/json' \
+      -d "$payload" \
+      "$RPC_URL"
 }
 
 # ============================================================================
@@ -46,77 +74,32 @@ run_test() {
 # ============================================================================
 echo "── Server Connectivity ──"
 
-run_test "MCP port check" "nc -z ${MCP_HOST} ${MCP_PORT} 2>/dev/null || echo 'port checked'"
-run_test "Server health" "curl -s -o /dev/null -w '%{http_code}' ${MCP_URL}/health 2>/dev/null | grep -q '200\|404' || echo '200'"
+run_test "MCP port reachable" "nc -z ${MCP_HOST} ${MCP_PORT}"
+run_test "Health endpoint returns ok" \
+  "curl -fsS --max-time 5 ${MCP_URL}/health | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8')); if(r.status!=='ok') process.exit(1);\""
 
 # ============================================================================
-# 2. MCP PROTOCOL
-# ============================================================================
-echo ""
-echo "── MCP Protocol ──"
-
-# Test MCP JSON-RPC calls
-run_test "MCP initialize" "echo '{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1}' | timeout 5 nc ${MCP_HOST} ${MCP_PORT} 2>/dev/null || echo 'initialized'"
-
-# ============================================================================
-# 3. COORDINATION TOOLS
+# 2. MCP JSON-RPC PROTOCOL
 # ============================================================================
 echo ""
-echo "── Coordination Tools ──"
+echo "── MCP JSON-RPC ──"
 
-run_test "swarm_init tool" "node -e \"console.log(JSON.stringify({tool:'swarm_init',args:{topology:'hierarchical'}}))\" || echo 'tool ok'"
-run_test "agent_spawn tool" "node -e \"console.log(JSON.stringify({tool:'agent_spawn',args:{type:'coder'}}))\" || echo 'tool ok'"
-run_test "task_orchestrate tool" "node -e \"console.log(JSON.stringify({tool:'task_orchestrate',args:{task:'test'}}))\" || echo 'tool ok'"
+run_test "initialize returns server info" \
+  "json_rpc '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}' | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8')); if(r.error||!r.result||!r.result.serverInfo) process.exit(1);\""
 
-# ============================================================================
-# 4. MONITORING TOOLS
-# ============================================================================
-echo ""
-echo "── Monitoring Tools ──"
+run_test "tools/list returns non-empty tools array" \
+  "json_rpc '{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}' | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8')); const tools=r.result&&r.result.tools; if(r.error||!Array.isArray(tools)||tools.length===0) process.exit(1);\""
 
-run_test "swarm_status tool" "echo 'swarm_status check' && echo 'ok'"
-run_test "agent_list tool" "echo 'agent_list check' && echo 'ok'"
-run_test "agent_metrics tool" "echo 'agent_metrics check' && echo 'ok'"
-run_test "task_status tool" "echo 'task_status check' && echo 'ok'"
-run_test "task_results tool" "echo 'task_results check' && echo 'ok'"
+run_test "tools/call hooks_list returns content" \
+  "json_rpc '{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"hooks_list\",\"arguments\":{}}}' | node -e \"const r=JSON.parse(require('fs').readFileSync(0,'utf8')); const content=r.result&&r.result.content; if(r.error||!Array.isArray(content)||content.length===0) process.exit(1);\""
 
 # ============================================================================
-# 5. MEMORY & NEURAL TOOLS
+# 3. NEGATIVE CHECKS
 # ============================================================================
 echo ""
-echo "── Memory & Neural Tools ──"
+echo "── Negative Checks ──"
 
-run_test "memory_usage tool" "echo 'memory_usage check' && echo 'ok'"
-run_test "neural_status tool" "echo 'neural_status check' && echo 'ok'"
-run_test "neural_train tool" "echo 'neural_train check' && echo 'ok'"
-run_test "neural_patterns tool" "echo 'neural_patterns check' && echo 'ok'"
-
-# ============================================================================
-# 6. GITHUB INTEGRATION TOOLS
-# ============================================================================
-echo ""
-echo "── GitHub Integration Tools ──"
-
-run_test "github_swarm tool" "echo 'github_swarm check' && echo 'ok'"
-run_test "repo_analyze tool" "echo 'repo_analyze check' && echo 'ok'"
-run_test "pr_enhance tool" "echo 'pr_enhance check' && echo 'ok'"
-run_test "issue_triage tool" "echo 'issue_triage check' && echo 'ok'"
-run_test "code_review tool" "echo 'code_review check' && echo 'ok'"
-
-# ============================================================================
-# 7. WORKER TOOLS (V3)
-# ============================================================================
-echo ""
-echo "── Worker Tools (V3) ──"
-
-run_test "worker/run tool" "echo 'worker/run check' && echo 'ok'"
-run_test "worker/status tool" "echo 'worker/status check' && echo 'ok'"
-run_test "worker/alerts tool" "echo 'worker/alerts check' && echo 'ok'"
-run_test "worker/history tool" "echo 'worker/history check' && echo 'ok'"
-run_test "worker/statusline tool" "echo 'worker/statusline check' && echo 'ok'"
-run_test "worker/run-all tool" "echo 'worker/run-all check' && echo 'ok'"
-run_test "worker/start tool" "echo 'worker/start check' && echo 'ok'"
-run_test "worker/stop tool" "echo 'worker/stop check' && echo 'ok'"
+run_negative_test "Invalid MCP endpoint fails" "curl -fsS --max-time 3 ${INVALID_MCP_URL}/health >/dev/null"
 
 # ============================================================================
 # SUMMARY
@@ -125,7 +108,7 @@ echo ""
 echo "=== MCP Server Summary ==="
 echo "Total: $TOTAL | Passed: $PASSED | Failed: $FAILED"
 
-if [ $FAILED -gt 0 ]; then
+if [ "$FAILED" -gt 0 ]; then
     exit 1
 fi
 exit 0


### PR DESCRIPTION
## Summary
- replace permissive placeholder assertions in `test-mcp-server.sh` with strict MCP checks
  - strict port + health checks
  - strict JSON-RPC assertions for `initialize`, `tools/list`, and `tools/call`
  - explicit negative test that must fail on invalid endpoint
- align docker regression MCP wiring for strict checks
  - set test-runner `MCP_SERVER_HOST=mcp-server`
  - start MCP server in HTTP transport on `0.0.0.0:3000`

## Why
Issue #17 reported that MCP regression tests were passing even when MCP endpoint was invalid due permissive `|| echo` placeholders.

## Validation
- `bash -n tests/docker-regression/scripts/test-mcp-server.sh`
- placeholder assertion scan confirms no `|| echo` fallbacks remain in MCP script
- negative run check:
  - `MCP_SERVER_HOST=127.0.0.1 MCP_SERVER_PORT=65530 bash tests/docker-regression/scripts/test-mcp-server.sh`
  - exits non-zero as expected

## Context
- Fixes #17
