### PR TITLE
fix(hooks): make intelligence --status metrics null-safe

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-intelligence-status.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-intelligence-status.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { hooksCommand } from '../src/commands/hooks.js';
+import { callMCPTool } from '../src/mcp-client.js';
+import { output } from '../src/output.js';
+import type { CommandContext } from '../src/types.js';
+
+vi.mock('../src/mcp-client.js', () => ({
+  callMCPTool: vi.fn(),
+  MCPClientError: class MCPClientError extends Error {
+    constructor(message: string, public toolName: string, public cause?: Error) {
+      super(message);
+      this.name = 'MCPClientError';
+    }
+  },
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: {
+    writeln: vi.fn(),
+    printInfo: vi.fn(),
+    printSuccess: vi.fn(),
+    printError: vi.fn(),
+    printWarning: vi.fn(),
+    printTable: vi.fn(),
+    printJson: vi.fn(),
+    printList: vi.fn(),
+    printBox: vi.fn(),
+    createSpinner: vi.fn(() => ({
+      start: vi.fn(),
+      succeed: vi.fn(),
+      fail: vi.fn(),
+      stop: vi.fn(),
+      setText: vi.fn(),
+    })),
+    highlight: (str: string) => str,
+    bold: (str: string) => str,
+    dim: (str: string) => str,
+    success: (str: string) => str,
+    error: (str: string) => str,
+    warning: (str: string) => str,
+    info: (str: string) => str,
+    progressBar: () => '[=====>    ]',
+    setColorEnabled: vi.fn(),
+  },
+}));
+
+vi.mock('../src/prompt.js', () => ({
+  select: vi.fn(),
+  confirm: vi.fn(),
+  input: vi.fn(),
+  multiSelect: vi.fn(),
+}));
+
+describe('hooks intelligence status', () => {
+  const mockedCallMCPTool = vi.mocked(callMCPTool);
+  const mockedOutput = vi.mocked(output);
+
+  beforeEach(() => {
+    mockedCallMCPTool.mockReset();
+    mockedOutput.printTable.mockClear();
+    mockedOutput.printError.mockClear();
+
+    mockedCallMCPTool.mockImplementation(async (toolName: string) => {
+      if (toolName !== 'hooks_intelligence') {
+        return {};
+      }
+
+      return {
+        mode: 'balanced',
+        status: 'active',
+        components: {
+          sona: {
+            enabled: true,
+            status: 'active',
+            learningTimeMs: undefined,
+            adaptationTimeMs: undefined,
+            trajectoriesRecorded: undefined,
+            patternsLearned: undefined,
+            avgQuality: undefined,
+          },
+          moe: {
+            enabled: true,
+            status: 'active',
+            expertsActive: undefined,
+            routingAccuracy: undefined,
+            loadBalance: undefined,
+          },
+          hnsw: {
+            enabled: false,
+            status: 'idle',
+            indexSize: undefined,
+            searchSpeedup: undefined,
+            memoryUsage: undefined,
+            dimension: undefined,
+          },
+          embeddings: {
+            provider: 'mock',
+            model: 'mock-model',
+            dimension: undefined,
+            cacheHitRate: undefined,
+          },
+        },
+        performance: {
+          flashAttention: '2.8x',
+          memoryReduction: '67%',
+          searchImprovement: '150x',
+          tokenReduction: '32%',
+          sweBenchScore: '84.8%',
+        },
+        lastTrainingMs: undefined,
+      };
+    });
+  });
+
+  it('does not crash and formats undefined component metrics with safe defaults', async () => {
+    const intelligenceCommand = hooksCommand.subcommands?.find(cmd => cmd.name === 'intelligence');
+    expect(intelligenceCommand).toBeDefined();
+
+    const ctx: CommandContext = {
+      args: [],
+      flags: {
+        _: [],
+        status: true,
+      },
+      cwd: process.cwd(),
+      interactive: false,
+    };
+
+    const result = await intelligenceCommand!.action!(ctx);
+
+    expect(result.success).toBe(true);
+    expect(mockedOutput.printError).not.toHaveBeenCalled();
+
+    const tableCalls = mockedOutput.printTable.mock.calls.map(([arg]) => arg as {
+      data?: Array<{ metric: string; value: string }>;
+    });
+
+    const sonaTable = tableCalls.find(call => call.data?.some(row => row.metric === 'Learning Time'));
+    expect(sonaTable?.data).toEqual(
+      expect.arrayContaining([
+        { metric: 'Learning Time', value: '0.000ms' },
+        { metric: 'Adaptation Time', value: '0.000ms' },
+        { metric: 'Avg Quality', value: '0.0%' },
+      ])
+    );
+
+    const moeTable = tableCalls.find(call => call.data?.some(row => row.metric === 'Routing Accuracy'));
+    expect(moeTable?.data).toEqual(
+      expect.arrayContaining([
+        { metric: 'Active Experts', value: '0' },
+        { metric: 'Routing Accuracy', value: '0.0%' },
+        { metric: 'Load Balance', value: '0.0%' },
+      ])
+    );
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -2199,11 +2199,11 @@ const intelligenceCommand: Command = {
           ],
           data: [
             { metric: 'Status', value: formatIntelligenceStatus(result.components.sona.status) },
-            { metric: 'Learning Time', value: `${result.components.sona.learningTimeMs.toFixed(3)}ms` },
-            { metric: 'Adaptation Time', value: `${result.components.sona.adaptationTimeMs.toFixed(3)}ms` },
-            { metric: 'Trajectories', value: result.components.sona.trajectoriesRecorded },
-            { metric: 'Patterns Learned', value: result.components.sona.patternsLearned },
-            { metric: 'Avg Quality', value: `${(result.components.sona.avgQuality * 100).toFixed(1)}%` }
+            { metric: 'Learning Time', value: formatMilliseconds(result.components.sona.learningTimeMs, 3) },
+            { metric: 'Adaptation Time', value: formatMilliseconds(result.components.sona.adaptationTimeMs, 3) },
+            { metric: 'Trajectories', value: formatCount(result.components.sona.trajectoriesRecorded) },
+            { metric: 'Patterns Learned', value: formatCount(result.components.sona.patternsLearned) },
+            { metric: 'Avg Quality', value: formatPercentage(result.components.sona.avgQuality, 1) }
           ]
         });
       } else {
@@ -2221,9 +2221,9 @@ const intelligenceCommand: Command = {
           ],
           data: [
             { metric: 'Status', value: formatIntelligenceStatus(result.components.moe.status) },
-            { metric: 'Active Experts', value: result.components.moe.expertsActive },
-            { metric: 'Routing Accuracy', value: `${(result.components.moe.routingAccuracy * 100).toFixed(1)}%` },
-            { metric: 'Load Balance', value: `${(result.components.moe.loadBalance * 100).toFixed(1)}%` }
+            { metric: 'Active Experts', value: formatCount(result.components.moe.expertsActive) },
+            { metric: 'Routing Accuracy', value: formatPercentage(result.components.moe.routingAccuracy, 1) },
+            { metric: 'Load Balance', value: formatPercentage(result.components.moe.loadBalance, 1) }
           ]
         });
       } else {
@@ -2241,10 +2241,10 @@ const intelligenceCommand: Command = {
           ],
           data: [
             { metric: 'Status', value: formatIntelligenceStatus(result.components.hnsw.status) },
-            { metric: 'Index Size', value: result.components.hnsw.indexSize.toLocaleString() },
-            { metric: 'Search Speedup', value: output.success(result.components.hnsw.searchSpeedup) },
-            { metric: 'Memory Usage', value: result.components.hnsw.memoryUsage },
-            { metric: 'Dimension', value: result.components.hnsw.dimension }
+            { metric: 'Index Size', value: formatCount(result.components.hnsw.indexSize) },
+            { metric: 'Search Speedup', value: output.success(result.components.hnsw.searchSpeedup ?? 'N/A') },
+            { metric: 'Memory Usage', value: result.components.hnsw.memoryUsage ?? 'N/A' },
+            { metric: 'Dimension', value: formatCount(result.components.hnsw.dimension) }
           ]
         });
       } else {
@@ -2260,10 +2260,10 @@ const intelligenceCommand: Command = {
           { key: 'value', header: 'Value', width: 20, align: 'right' }
         ],
         data: [
-          { metric: 'Provider', value: result.components.embeddings.provider },
-          { metric: 'Model', value: result.components.embeddings.model },
-          { metric: 'Dimension', value: result.components.embeddings.dimension },
-          { metric: 'Cache Hit Rate', value: `${(result.components.embeddings.cacheHitRate * 100).toFixed(1)}%` }
+          { metric: 'Provider', value: result.components.embeddings.provider ?? 'N/A' },
+          { metric: 'Model', value: result.components.embeddings.model ?? 'N/A' },
+          { metric: 'Dimension', value: formatCount(result.components.embeddings.dimension) },
+          { metric: 'Cache Hit Rate', value: formatPercentage(result.components.embeddings.cacheHitRate, 1) }
         ]
       });
 
@@ -2306,6 +2306,22 @@ function formatIntelligenceStatus(status: string): string {
     default:
       return status;
   }
+}
+
+function toSafeNumber(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function formatMilliseconds(value: unknown, decimals = 2): string {
+  return `${toSafeNumber(value).toFixed(decimals)}ms`;
+}
+
+function formatPercentage(value: unknown, decimals = 1): string {
+  return `${(toSafeNumber(value) * 100).toFixed(decimals)}%`;
+}
+
+function formatCount(value: unknown): string {
+  return toSafeNumber(value).toLocaleString();
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- fix crash in hooks intelligence --status when fresh installs return undefined numeric metrics
- apply null-safe formatting for SONA/MoE/HNSW/Embeddings numeric status fields
- add regression test for undefined metrics payload

## Validation
- npm test -- __tests__/hooks-intelligence-status.test.ts
- npm test -- __tests__/hooks-intelligence-status.test.ts __tests__/hooks-command-stdin.test.ts
- npm test (fails on pre-existing unrelated baseline failures in commands.test.ts and p1-commands.test.ts)

Closes #33
Refs upstream: https://github.com/ruvnet/claude-flow/issues/1074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of intelligence metrics that previously showed as undefined or missing, now with safe default values.
  * Enhanced formatting for intelligence metrics including time measurements and quality indicators.

* **Tests**
  * Added test coverage for intelligence metrics reporting with edge cases and missing data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->