### PR TITLE
fix(statusline): detect active Claude model dynamically

### DIFF
--- a/v3/@claude-flow/cli/__tests__/statusline-generator.test.ts
+++ b/v3/@claude-flow/cli/__tests__/statusline-generator.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { generateStatuslineScript } from '../src/init/statusline-generator.js';
+import { DEFAULT_INIT_OPTIONS } from '../src/init/types.js';
+
+describe('statusline generator model detection', () => {
+  it('uses dynamic model parsing instead of hardcoded Opus label', () => {
+    const script = generateStatuslineScript(DEFAULT_INIT_OPTIONS);
+
+    expect(script).toContain('function formatModelName(modelId)');
+    expect(script).toContain("parseFamilyVersion('opus', 'Opus')");
+    expect(script).toContain("parseFamilyVersion('sonnet', 'Sonnet')");
+    expect(script).toContain("parseFamilyVersion('haiku', 'Haiku')");
+    expect(script).not.toContain("if (modelId.includes('opus')) modelName = 'Opus 4.5';");
+    expect(script).not.toContain('Opus 4.5');
+  });
+
+  it('falls back to settings model lookup when default label is still active', () => {
+    const script = generateStatuslineScript(DEFAULT_INIT_OPTIONS);
+    expect(script).toContain("if (modelName === '🤖 Claude Code')");
+  });
+});

--- a/v3/@claude-flow/cli/src/init/statusline-generator.ts
+++ b/v3/@claude-flow/cli/src/init/statusline-generator.ts
@@ -8,7 +8,7 @@ import type { InitOptions, StatuslineConfig } from './types.js';
 /**
  * Generate statusline configuration script
  * Matches the advanced format:
- * ▊ Claude Flow V3 ● user  │  ⎇ v3  │  Opus 4.5
+ * ▊ Claude Flow V3 ● user  │  ⎇ v3  │  Opus 4.6
  * ─────────────────────────────────────────────────────
  * 🏗️  DDD Domains    [●●●●●]  5/5    ⚡ HNSW 12500x (or 📚 22.9k patterns)
  * 🤖 Swarm  ◉ [12/15]  👥 0    🟢 CVE 3/3    💾 5177MB    📂  56%    🧠  30%
@@ -67,6 +67,41 @@ const c = {
   brightWhite: '\\x1b[1;37m',
 };
 
+function formatModelName(modelId) {
+  if (typeof modelId !== 'string' || modelId.length === 0) {
+    return '🤖 Claude Code';
+  }
+
+  const normalized = modelId.toLowerCase();
+
+  const parseFamilyVersion = (family, label) => {
+    const forward = normalized.match(new RegExp(family + '-(\\\\d+)(?:-(\\\\d+))?'));
+    if (forward) {
+      return label + ' ' + forward[1] + (forward[2] ? '.' + forward[2] : '');
+    }
+
+    const reverse = normalized.match(new RegExp('(\\\\d+)(?:-(\\\\d+))?-' + family));
+    if (reverse) {
+      return label + ' ' + reverse[1] + (reverse[2] ? '.' + reverse[2] : '');
+    }
+
+    return null;
+  };
+
+  return (
+    parseFamilyVersion('opus', 'Opus')
+    || parseFamilyVersion('sonnet', 'Sonnet')
+    || parseFamilyVersion('haiku', 'Haiku')
+    || modelId
+      .replace(/^claude-/, '')
+      .replace(/-\\\\d{8}$/, '')
+      .split('-')
+      .filter(Boolean)
+      .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' ')
+  );
+}
+
 // Get user info
 function getUserInfo() {
   let name = 'user';
@@ -118,11 +153,7 @@ function getUserInfo() {
             }
           }
 
-          // Parse model ID to human-readable name
-          if (modelId.includes('opus')) modelName = 'Opus 4.5';
-          else if (modelId.includes('sonnet')) modelName = 'Sonnet 4';
-          else if (modelId.includes('haiku')) modelName = 'Haiku 4.5';
-          else modelName = modelId.split('-').slice(1, 3).join(' ');
+          modelName = formatModelName(modelId);
         }
       }
     }
@@ -131,20 +162,17 @@ function getUserInfo() {
   }
 
   // Fallback: check project's .claude/settings.json for model
-  if (modelName === 'Unknown') {
+  if (modelName === '🤖 Claude Code') {
     try {
       const settingsPath = path.join(process.cwd(), '.claude', 'settings.json');
       if (fs.existsSync(settingsPath)) {
         const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
         if (settings.model) {
-          if (settings.model.includes('opus')) modelName = 'Opus 4.5';
-          else if (settings.model.includes('sonnet')) modelName = 'Sonnet 4';
-          else if (settings.model.includes('haiku')) modelName = 'Haiku 4.5';
-          else modelName = settings.model.split('-').slice(1, 3).join(' ');
+          modelName = formatModelName(settings.model);
         }
       }
     } catch (e) {
-      // Keep Unknown
+      // Keep default label
     }
   }
 


### PR DESCRIPTION
## Summary
- replace hardcoded model labels in statusline model detection (e.g. Opus 4.5)
- parse Claude model IDs dynamically for opus/sonnet/haiku families, including versions like 4-6
- align fallback logic to read .claude/settings.json when default model label is still active
- keep generated helper and committed helper in sync

## Tests
- npm test -- __tests__/statusline-generator.test.ts
- npm test (fails on pre-existing baseline failures in commands.test.ts and p1-commands.test.ts)

Closes #35
Refs upstream: https://github.com/ruvnet/claude-flow/issues/1083