### PR TITLE
fix(daemon): avoid macOS worker starvation from strict resource checks

### DIFF
--- a/v3/@claude-flow/cli/__tests__/daemon-background-quiet.test.ts
+++ b/v3/@claude-flow/cli/__tests__/daemon-background-quiet.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { daemonCommand } from '../src/commands/daemon.js';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import type { CommandContext } from '../src/types.js';
+
+vi.mock('../src/services/worker-daemon.js', () => ({
+  WorkerDaemon: class WorkerDaemon {},
+  getDaemon: vi.fn(),
+  startDaemon: vi.fn(),
+  stopDaemon: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({
+    pid: 4321,
+    unref: vi.fn(),
+  })),
+  execFile: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(() => ''),
+  unlinkSync: vi.fn(),
+  openSync: vi.fn(() => 1),
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: {
+    writeln: vi.fn(),
+    printInfo: vi.fn(),
+    printSuccess: vi.fn(),
+    printError: vi.fn(),
+    printWarning: vi.fn(),
+    printTable: vi.fn(),
+    printJson: vi.fn(),
+    printList: vi.fn(),
+    printBox: vi.fn(),
+    createSpinner: vi.fn(() => ({
+      start: vi.fn(),
+      succeed: vi.fn(),
+      fail: vi.fn(),
+      stop: vi.fn(),
+    })),
+    highlight: (str: string) => str,
+    bold: (str: string) => str,
+    dim: (str: string) => str,
+    success: (str: string) => str,
+    error: (str: string) => str,
+    warning: (str: string) => str,
+    info: (str: string) => str,
+    progressBar: () => '[=====>    ]',
+    setColorEnabled: vi.fn(),
+  },
+}));
+
+describe('daemon background start quiet propagation', () => {
+  const mockedSpawn = vi.mocked(spawn);
+  const mockedFs = vi.mocked(fs);
+  const originalDaemonEnv = process.env.CLAUDE_FLOW_DAEMON;
+
+  beforeEach(() => {
+    mockedSpawn.mockClear();
+    mockedFs.existsSync.mockImplementation(() => true);
+    process.env.CLAUDE_FLOW_DAEMON = '1'; // Skip already-running background PID check path
+  });
+
+  afterEach(() => {
+    if (originalDaemonEnv === undefined) {
+      delete process.env.CLAUDE_FLOW_DAEMON;
+    } else {
+      process.env.CLAUDE_FLOW_DAEMON = originalDaemonEnv;
+    }
+  });
+
+  it('does not force --quiet when quiet flag is false', async () => {
+    const start = daemonCommand.subcommands?.find(cmd => cmd.name === 'start');
+    expect(start).toBeDefined();
+
+    const ctx: CommandContext = {
+      args: [],
+      flags: { _: [], quiet: false, foreground: false },
+      cwd: process.cwd(),
+      interactive: false,
+    };
+
+    const result = await start!.action!(ctx);
+    expect(result.success).toBe(true);
+
+    const spawnArgs = mockedSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain('daemon');
+    expect(spawnArgs).toContain('start');
+    expect(spawnArgs).toContain('--foreground');
+    expect(spawnArgs).not.toContain('--quiet');
+  });
+
+  it('passes --quiet when quiet flag is true', async () => {
+    const start = daemonCommand.subcommands?.find(cmd => cmd.name === 'start');
+    expect(start).toBeDefined();
+
+    const ctx: CommandContext = {
+      args: [],
+      flags: { _: [], quiet: true, foreground: false },
+      cwd: process.cwd(),
+      interactive: false,
+    };
+
+    const result = await start!.action!(ctx);
+    expect(result.success).toBe(true);
+
+    const spawnArgs = mockedSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain('--quiet');
+  });
+});

--- a/v3/@claude-flow/cli/__tests__/worker-daemon-thresholds.test.ts
+++ b/v3/@claude-flow/cli/__tests__/worker-daemon-thresholds.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultResourceThresholds } from '../src/services/worker-daemon.js';
+
+describe('worker daemon resource thresholds', () => {
+  it('scales CPU threshold with core count', () => {
+    const thresholds = getDefaultResourceThresholds('linux', 8);
+    expect(thresholds.maxCpuLoad).toBe(24);
+  });
+
+  it('uses macOS-friendly free memory threshold', () => {
+    const thresholds = getDefaultResourceThresholds('darwin', 8);
+    expect(thresholds.minFreeMemoryPercent).toBe(1);
+  });
+
+  it('keeps stricter free memory threshold on non-macOS', () => {
+    const thresholds = getDefaultResourceThresholds('linux', 8);
+    expect(thresholds.minFreeMemoryPercent).toBe(20);
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/daemon.ts
+++ b/v3/@claude-flow/cli/src/commands/daemon.ts
@@ -212,10 +212,12 @@ async function startBackgroundDaemon(projectRoot: string, quiet: boolean): Promi
 
   // Use spawn with explicit arguments instead of shell string interpolation
   // This prevents command injection via paths
-  const child = spawn(process.execPath, [
-    cliPath,
-    'daemon', 'start', '--foreground', '--quiet'
-  ], {
+  const daemonArgs = [cliPath, 'daemon', 'start', '--foreground'];
+  if (quiet) {
+    daemonArgs.push('--quiet');
+  }
+
+  const child = spawn(process.execPath, daemonArgs, {
     cwd: resolvedRoot,
     detached: true,
     stdio: ['ignore', fs.openSync(logFile, 'a'), fs.openSync(logFile, 'a')],


### PR DESCRIPTION
## Summary
- replace static resource defaults with CPU-aware thresholds in worker daemon
- use macOS-friendly free-memory threshold (1%) to avoid perpetual deferral
- stop forcing --quiet in detached daemon spawn; propagate quiet flag correctly
- add focused tests for threshold defaults and background spawn args

## Tests
- npm test -- __tests__/worker-daemon-thresholds.test.ts __tests__/daemon-background-quiet.test.ts
- npm test (fails on pre-existing baseline failures in commands.test.ts and p1-commands.test.ts)

Closes #37
Refs upstream: https://github.com/ruvnet/claude-flow/issues/1077