### PR TITLE
fix(skills): normalize SKILL.md names to directory slugs

### DIFF
--- a/.claude/skills/agentdb-advanced/SKILL.md
+++ b/.claude/skills/agentdb-advanced/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "AgentDB Advanced Features"
+name: agentdb-advanced
 description: "Master advanced AgentDB features including QUIC synchronization, multi-database management, custom distance metrics, hybrid search, and distributed systems integration. Use when building distributed AI systems, multi-agent coordination, or advanced vector search applications."
 ---
 

--- a/.claude/skills/agentdb-learning/SKILL.md
+++ b/.claude/skills/agentdb-learning/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "AgentDB Learning Plugins"
+name: agentdb-learning
 description: "Create and train AI learning plugins with AgentDB's 9 reinforcement learning algorithms. Includes Decision Transformer, Q-Learning, SARSA, Actor-Critic, and more. Use when building self-learning agents, implementing RL, or optimizing agent behavior through experience."
 ---
 

--- a/.claude/skills/agentdb-memory-patterns/SKILL.md
+++ b/.claude/skills/agentdb-memory-patterns/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "AgentDB Memory Patterns"
+name: agentdb-memory-patterns
 description: "Implement persistent memory patterns for AI agents using AgentDB. Includes session memory, long-term storage, pattern learning, and context management. Use when building stateful agents, chat systems, or intelligent assistants."
 ---
 

--- a/.claude/skills/agentdb-optimization/SKILL.md
+++ b/.claude/skills/agentdb-optimization/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "AgentDB Performance Optimization"
+name: agentdb-optimization
 description: "Optimize AgentDB performance with quantization (4-32x memory reduction), HNSW indexing (150x faster search), caching, and batch operations. Use when optimizing memory usage, improving search speed, or scaling to millions of vectors."
 ---
 

--- a/.claude/skills/agentdb-vector-search/SKILL.md
+++ b/.claude/skills/agentdb-vector-search/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "AgentDB Vector Search"
+name: agentdb-vector-search
 description: "Implement semantic vector search with AgentDB for intelligent document retrieval, similarity matching, and context-aware querying. Use when building RAG systems, semantic search engines, or intelligent knowledge bases."
 ---
 

--- a/.claude/skills/hooks-automation/SKILL.md
+++ b/.claude/skills/hooks-automation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Hooks Automation
+name: hooks-automation
 description: Automated coordination, formatting, and learning from Claude Code operations using intelligent hooks with MCP integration. Includes pre/post task hooks, session management, Git integration, memory coordination, and neural pattern training for enhanced development workflows.
 ---
 

--- a/.claude/skills/pair-programming/SKILL.md
+++ b/.claude/skills/pair-programming/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Pair Programming
+name: pair-programming
 description: AI-assisted pair programming with multiple modes (driver/navigator/switch), real-time verification, quality monitoring, and comprehensive testing. Supports TDD, debugging, refactoring, and learning sessions. Features automatic role switching, continuous code review, security scanning, and performance optimization with truth-score verification.
 ---
 

--- a/.claude/skills/reasoningbank-agentdb/SKILL.md
+++ b/.claude/skills/reasoningbank-agentdb/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "ReasoningBank with AgentDB"
+name: reasoningbank-agentdb
 description: "Implement ReasoningBank adaptive learning with AgentDB's 150x faster vector database. Includes trajectory tracking, verdict judgment, memory distillation, and pattern recognition. Use when building self-learning agents, optimizing decision-making, or implementing experience replay systems."
 ---
 

--- a/.claude/skills/reasoningbank-intelligence/SKILL.md
+++ b/.claude/skills/reasoningbank-intelligence/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "ReasoningBank Intelligence"
+name: reasoningbank-intelligence
 description: "Implement adaptive learning with ReasoningBank for pattern recognition, strategy optimization, and continuous improvement. Use when building self-learning agents, optimizing workflows, or implementing meta-cognitive systems."
 ---
 

--- a/.claude/skills/skill-builder/SKILL.md
+++ b/.claude/skills/skill-builder/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "Skill Builder"
+name: skill-builder
 description: "Create new Claude Code Skills with proper YAML frontmatter, progressive disclosure structure, and complete directory organization. Use when you need to build custom skills for specific workflows, generate skill templates, or understand the Claude Skills specification."
 ---
 

--- a/.claude/skills/swarm-orchestration/SKILL.md
+++ b/.claude/skills/swarm-orchestration/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "Swarm Orchestration"
+name: swarm-orchestration
 description: "Orchestrate multi-agent swarms with agentic-flow for parallel task execution, dynamic topology, and intelligent coordination. Use when scaling beyond single agents, implementing complex workflows, or building distributed AI systems."
 ---
 

--- a/.claude/skills/v3-cli-modernization/SKILL.md
+++ b/.claude/skills/v3-cli-modernization/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 CLI Modernization"
+name: v3-cli-modernization
 description: "CLI modernization and hooks system enhancement for claude-flow v3. Implements interactive prompts, command decomposition, enhanced hooks integration, and intelligent workflow automation."
 ---
 

--- a/.claude/skills/v3-core-implementation/SKILL.md
+++ b/.claude/skills/v3-core-implementation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 Core Implementation"
+name: v3-core-implementation
 description: "Core module implementation for claude-flow v3. Implements DDD domains, clean architecture patterns, dependency injection, and modular TypeScript codebase with comprehensive testing."
 ---
 

--- a/.claude/skills/v3-ddd-architecture/SKILL.md
+++ b/.claude/skills/v3-ddd-architecture/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 DDD Architecture"
+name: v3-ddd-architecture
 description: "Domain-Driven Design architecture for claude-flow v3. Implements modular, bounded context architecture with clean separation of concerns and microkernel pattern."
 ---
 

--- a/.claude/skills/v3-integration-deep/SKILL.md
+++ b/.claude/skills/v3-integration-deep/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 Deep Integration"
+name: v3-integration-deep
 description: "Deep agentic-flow@alpha integration implementing ADR-001. Eliminates 10,000+ duplicate lines by building claude-flow as specialized extension rather than parallel implementation."
 ---
 

--- a/.claude/skills/v3-mcp-optimization/SKILL.md
+++ b/.claude/skills/v3-mcp-optimization/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 MCP Optimization"
+name: v3-mcp-optimization
 description: "MCP server optimization and transport layer enhancement for claude-flow v3. Implements connection pooling, load balancing, tool registry optimization, and performance monitoring for sub-100ms response times."
 ---
 

--- a/.claude/skills/v3-memory-unification/SKILL.md
+++ b/.claude/skills/v3-memory-unification/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 Memory Unification"
+name: v3-memory-unification
 description: "Unify 6+ memory systems into AgentDB with HNSW indexing for 150x-12,500x search improvements. Implements ADR-006 (Unified Memory Service) and ADR-009 (Hybrid Memory Backend)."
 ---
 

--- a/.claude/skills/v3-performance-optimization/SKILL.md
+++ b/.claude/skills/v3-performance-optimization/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 Performance Optimization"
+name: v3-performance-optimization
 description: "Achieve aggressive v3 performance targets: 2.49x-7.47x Flash Attention speedup, 150x-12,500x search improvements, 50-75% memory reduction. Comprehensive benchmarking and optimization suite."
 ---
 

--- a/.claude/skills/v3-security-overhaul/SKILL.md
+++ b/.claude/skills/v3-security-overhaul/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 Security Overhaul"
+name: v3-security-overhaul
 description: "Complete security architecture overhaul for claude-flow v3. Addresses critical CVEs (CVE-1, CVE-2, CVE-3) and implements secure-by-default patterns. Use for security-first v3 implementation."
 ---
 

--- a/.claude/skills/v3-swarm-coordination/SKILL.md
+++ b/.claude/skills/v3-swarm-coordination/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "V3 Swarm Coordination"
+name: v3-swarm-coordination
 description: "15-agent hierarchical mesh coordination for v3 implementation. Orchestrates parallel execution across security, core, and integration domains following 10 ADRs with 14-week timeline."
 ---
 

--- a/.claude/skills/verification-quality/SKILL.md
+++ b/.claude/skills/verification-quality/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "Verification & Quality Assurance"
+name: verification-quality
 description: "Comprehensive truth scoring, code quality verification, and automatic rollback system with 0.95 accuracy threshold for ensuring high-quality agent outputs and codebase reliability."
 version: "2.0.0"
 category: "quality-assurance"


### PR DESCRIPTION
## Summary
- update bundled skill frontmatter name fields to match their directory slug
- normalize 21 affected SKILL.md files in .claude/skills

## Verification
- scripted check for name vs directory mismatch now returns 0

Closes #39
Refs upstream: https://github.com/ruvnet/claude-flow/issues/1054