### PR TITLE
fix(hooks): auto-generate pre-task id when omitted

### DIFF
--- a/v3/@claude-flow/cli/__tests__/hooks-pre-task-taskid.test.ts
+++ b/v3/@claude-flow/cli/__tests__/hooks-pre-task-taskid.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { hooksCommand } from '../src/commands/hooks.js';
+import { callMCPTool } from '../src/mcp-client.js';
+import type { CommandContext } from '../src/types.js';
+
+vi.mock('../src/mcp-client.js', () => ({
+  callMCPTool: vi.fn(),
+  MCPClientError: class MCPClientError extends Error {
+    constructor(message: string, public toolName: string, public cause?: Error) {
+      super(message);
+      this.name = 'MCPClientError';
+    }
+  },
+}));
+
+vi.mock('../src/output.js', () => ({
+  output: {
+    writeln: vi.fn(),
+    printInfo: vi.fn(),
+    printSuccess: vi.fn(),
+    printError: vi.fn(),
+    printWarning: vi.fn(),
+    printTable: vi.fn(),
+    printJson: vi.fn(),
+    printList: vi.fn(),
+    printBox: vi.fn(),
+    createSpinner: vi.fn(() => ({
+      start: vi.fn(),
+      succeed: vi.fn(),
+      fail: vi.fn(),
+      stop: vi.fn(),
+      setText: vi.fn(),
+    })),
+    highlight: (str: string) => str,
+    bold: (str: string) => str,
+    dim: (str: string) => str,
+    success: (str: string) => str,
+    error: (str: string) => str,
+    warning: (str: string) => str,
+    info: (str: string) => str,
+    progressBar: () => '[=====>    ]',
+    setColorEnabled: vi.fn(),
+  },
+}));
+
+vi.mock('../src/prompt.js', () => ({
+  select: vi.fn(),
+  confirm: vi.fn(),
+  input: vi.fn(),
+  multiSelect: vi.fn(),
+}));
+
+describe('hooks pre-task task-id behavior', () => {
+  const mockedCallMCPTool = vi.mocked(callMCPTool);
+
+  beforeEach(() => {
+    mockedCallMCPTool.mockReset();
+    mockedCallMCPTool.mockImplementation(async (toolName: string, input: Record<string, unknown>) => {
+      if (toolName !== 'hooks_pre-task') {
+        return {};
+      }
+
+      return {
+        taskId: input.taskId,
+        description: input.description,
+        suggestedAgents: [],
+        complexity: 'low',
+        estimatedDuration: '5m',
+        risks: [],
+        recommendations: [],
+      };
+    });
+  });
+
+  it('auto-generates task-id when omitted', async () => {
+    const preTask = hooksCommand.subcommands?.find(cmd => cmd.name === 'pre-task');
+    expect(preTask).toBeDefined();
+
+    const ctx: CommandContext = {
+      args: [],
+      flags: {
+        _: [],
+        description: 'Implement feature X',
+        format: 'json',
+      },
+      cwd: process.cwd(),
+      interactive: false,
+    };
+
+    const result = await preTask!.action!(ctx);
+    expect(result.success).toBe(true);
+
+    const callArgs = mockedCallMCPTool.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(callArgs.taskId).toEqual(expect.stringMatching(/^task_\d+_[a-z0-9]{6}$/));
+  });
+
+  it('preserves explicit task-id when provided', async () => {
+    const preTask = hooksCommand.subcommands?.find(cmd => cmd.name === 'pre-task');
+    expect(preTask).toBeDefined();
+
+    const ctx: CommandContext = {
+      args: [],
+      flags: {
+        _: [],
+        taskId: 'task-explicit-123',
+        description: 'Fix auth bug',
+        format: 'json',
+      },
+      cwd: process.cwd(),
+      interactive: false,
+    };
+
+    const result = await preTask!.action!(ctx);
+    expect(result.success).toBe(true);
+    expect(mockedCallMCPTool).toHaveBeenCalledWith(
+      'hooks_pre-task',
+      expect.objectContaining({
+        taskId: 'task-explicit-123',
+        description: 'Fix auth bug',
+      })
+    );
+  });
+});

--- a/v3/@claude-flow/cli/src/commands/hooks.ts
+++ b/v3/@claude-flow/cli/src/commands/hooks.ts
@@ -1573,7 +1573,7 @@ const preTaskCommand: Command = {
       short: 'i',
       description: 'Unique task identifier',
       type: 'string',
-      required: true
+      required: false
     },
     {
       name: 'description',
@@ -1591,15 +1591,15 @@ const preTaskCommand: Command = {
     }
   ],
   examples: [
-    { command: 'claude-flow hooks pre-task -i task-123 -d "Fix auth bug"', description: 'Record task start' },
+    { command: 'claude-flow hooks pre-task -d "Fix auth bug"', description: 'Record task start (auto ID)' },
     { command: 'claude-flow hooks pre-task -i task-456 -d "Implement feature" --auto-spawn', description: 'With auto-spawn' }
   ],
   action: async (ctx: CommandContext): Promise<CommandResult> => {
-    const taskId = ctx.flags.taskId as string;
+    const taskId = (ctx.flags.taskId as string) || `task_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     const description = ctx.args[0] || ctx.flags.description as string;
 
-    if (!taskId || !description) {
-      output.printError('Task ID and description are required.');
+    if (!description) {
+      output.printError('Task description is required.');
       return { success: false, exitCode: 1 };
     }
 


### PR DESCRIPTION
## Summary
- make hooks pre-task task-id optional
- auto-generate task id when not provided
- keep explicit task-id path unchanged
- add regression tests for omitted and explicit task-id scenarios

## Tests
- npm test -- __tests__/hooks-pre-task-taskid.test.ts __tests__/hooks-command-stdin.test.ts __tests__/hooks-intelligence-status.test.ts
- npm test (fails on pre-existing baseline failures in commands.test.ts and p1-commands.test.ts)

Closes #41
Refs upstream: https://github.com/ruvnet/claude-flow/issues/1055