### PR TITLE
fix(hooks): default generated init hook timeout to 10s

### DIFF
--- a/v3/@claude-flow/cli/__tests__/settings-generator.test.ts
+++ b/v3/@claude-flow/cli/__tests__/settings-generator.test.ts
@@ -8,6 +8,15 @@ function getEditHookCommand(settings: Record<string, unknown>, event: 'PreToolUs
   return eventHooks[0].hooks[0].command;
 }
 
+function getHookTimeout(
+  settings: Record<string, unknown>,
+  event: 'PreToolUse' | 'SessionStart',
+  hookIndex = 0
+): number {
+  const hooks = settings.hooks as Record<string, Array<{ hooks: Array<{ timeout: number }> }>>;
+  return hooks[event][0].hooks[hookIndex].timeout;
+}
+
 describe('settings-generator hooks commands', () => {
   it('uses direct pre-edit command without file-path shell guard', () => {
     const settings = generateSettings({ ...DEFAULT_INIT_OPTIONS }) as Record<string, unknown>;
@@ -23,5 +32,15 @@ describe('settings-generator hooks commands', () => {
 
     expect(command).toContain('hooks post-edit --file "$TOOL_INPUT_file_path"');
     expect(command).not.toContain('[ -n "$TOOL_INPUT_file_path" ] &&');
+  });
+
+  it('uses 10000ms as default hook timeout for generated PreToolUse hooks', () => {
+    const settings = generateSettings({ ...DEFAULT_INIT_OPTIONS }) as Record<string, unknown>;
+    expect(getHookTimeout(settings, 'PreToolUse')).toBe(10000);
+  });
+
+  it('uses configured default timeout for SessionStart daemon hook', () => {
+    const settings = generateSettings({ ...DEFAULT_INIT_OPTIONS }) as Record<string, unknown>;
+    expect(getHookTimeout(settings, 'SessionStart', 0)).toBe(10000);
   });
 });

--- a/v3/@claude-flow/cli/src/init/settings-generator.ts
+++ b/v3/@claude-flow/cli/src/init/settings-generator.ts
@@ -255,7 +255,7 @@ function generateHooksConfig(config: HooksConfig): object {
           {
             type: 'command',
             command: 'npx @claude-flow/cli@latest daemon start --quiet 2>/dev/null || true',
-            timeout: 5000,
+            timeout: config.timeout,
             continueOnError: true,
           },
           {

--- a/v3/@claude-flow/cli/src/init/types.ts
+++ b/v3/@claude-flow/cli/src/init/types.ts
@@ -317,7 +317,7 @@ export const DEFAULT_INIT_OPTIONS: InitOptions = {
     sessionStart: true,
     stop: true,
     notification: true,
-    timeout: 5000,
+    timeout: 10000,
     continueOnError: true,
   },
   skills: {


### PR DESCRIPTION
## Summary
- raise default init hook timeout from 5000ms to 10000ms
- make SessionStart daemon hook reuse configured hook timeout instead of hardcoded 5000ms
- add tests to lock 10000ms defaults in generated settings

## Tests
- npm test -- __tests__/settings-generator.test.ts
- npm test (fails on pre-existing baseline failures in commands.test.ts and p1-commands.test.ts)

Closes #43
Refs upstream: https://github.com/ruvnet/claude-flow/issues/1060