### PR TITLE
chore(v2): deprecate legacy MCP wrapper entrypoints

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `neural init` and `goal init` script entrypoints are restored with working `scripts/init-*.js` targets.
 - v2 CLI init command wiring now points at existing simple-command handlers for `neural init` and `goal init`.
 
+### Deprecated
+- Internal MCP wrapper entrypoints are now explicitly marked deprecated and are not part of the v2 public startup contract:
+  - `src/mcp/server-with-wrapper.ts`
+  - `src/mcp/server-wrapper-mode.ts`
+  - `src/mcp/integrate-wrapper.ts`
+- Supported MCP startup path remains: `claude-flow mcp start`.
+
 ## [2.7.35] - 2025-11-13
 
 ### Added

--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.47] - 2026-02-08
+
+### Fixed
+- Package contract metadata now points to existing artifacts:
+  - `main` resolves via `cli.mjs` (ESM shim) instead of a missing path.
+  - `start` routes to `scripts/start-deprecated.js` with explicit deprecation guidance instead of `MODULE_NOT_FOUND`.
+  - `files[]` removes stale publish entries and now references existing paths only.
+- Verification and Docker test surfaces now use defined coverage scripts:
+  - `npm run coverage` -> `npm run test:coverage`
+  - `npm run test:features:coverage` -> `npm run test:coverage`
+
+### Changed
+- `neural init` and `goal init` script entrypoints are restored with working `scripts/init-*.js` targets.
+- v2 CLI init command wiring now points at existing simple-command handlers for `neural init` and `goal init`.
+
 ## [2.7.35] - 2025-11-13
 
 ### Added

--- a/v2/bin/verification-integration.js
+++ b/v2/bin/verification-integration.js
@@ -300,7 +300,7 @@ export class VerificationMiddleware {
 
   async checkTestCoverage() {
     try {
-      const { stdout } = await execAsync('npm run coverage 2>&1 || true');
+      const { stdout } = await execAsync('npm run test:coverage 2>&1 || true');
       const match = stdout.match(/(\d+(\.\d+)?)\s*%/);
       const percentage = match ? parseFloat(match[1]) : 0;
       return { percentage };

--- a/v2/cli.mjs
+++ b/v2/cli.mjs
@@ -1,0 +1,21 @@
+/**
+ * v2 module entrypoint shim.
+ *
+ * v2 is primarily a CLI package. This file exists to keep the published
+ * module contract from pointing at a missing path.
+ */
+
+export const deprecated = true;
+
+export const message =
+  'claude-flow v2 module import is deprecated; use the CLI binary (`claude-flow`) instead.';
+
+export function getDeprecationNotice() {
+  return message;
+}
+
+export default {
+  deprecated,
+  message,
+  getDeprecationNotice,
+};

--- a/v2/docker/Dockerfile.test
+++ b/v2/docker/Dockerfile.test
@@ -17,7 +17,7 @@ COPY . .
 
 # Run tests
 RUN npm run typecheck
-RUN npm run test:features:coverage
+RUN npm run test:coverage
 RUN npm run build
 
 # Simulate npx execution

--- a/v2/docs/AGENTIC_FLOW_INTEGRATION_REVIEW.md
+++ b/v2/docs/AGENTIC_FLOW_INTEGRATION_REVIEW.md
@@ -213,14 +213,14 @@ import * as ReasoningBank from 'agentic-flow/reasoningbank';
 - ✅ `tests/integration/mcp-pattern-persistence.test.js`
 - ✅ `tests/integration/agentdb/compatibility.test.js`
 
-**Validation Scripts (in agentic-flow):**
+**Validation Scripts (current v2 package):**
 ```bash
-npm run validate              # All validations
-npm run validate:sdk          # SDK validation
-npm run validate:claude-flow  # Claude-flow specific tests
-npm run test:memory          # Memory system tests
-npm run test:coordination    # Coordination tests
-npm run test:hybrid          # Hybrid system tests
+npm run typecheck         # Type safety checks
+npm run test              # Baseline test run
+npm run test:integration  # Integration coverage
+npm run test:coverage     # Coverage report
+npm run diagnostics       # Runtime diagnostics
+npm run health-check      # Health-check routine
 ```
 
 **Status:** ✅ Comprehensive test coverage
@@ -361,7 +361,7 @@ npm list agentic-flow
 **Step 3: Run Tests**
 ```bash
 npm run test:integration
-npm run validate:claude-flow  # If agentic-flow scripts are accessible
+npm run test:coverage
 ```
 
 **Step 4: Update Comments**

--- a/v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md
+++ b/v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md
@@ -1,0 +1,40 @@
+# MCP Wrapper Entrypoints Deprecation (v2)
+
+## Summary
+
+This note records the investigation outcome for legacy MCP wrapper entrypoints in v2 and defines the deprecate-first path.
+
+## Investigated Files
+
+- `src/mcp/server-with-wrapper.ts`
+- `src/mcp/server-wrapper-mode.ts`
+- `src/mcp/integrate-wrapper.ts`
+
+## Evidence
+
+1. `v2/package.json` exposes only one binary:
+   - `bin.claude-flow -> bin/claude-flow.js`
+2. `v2/package.json` has no script/bin wiring to the wrapper entrypoint files above.
+3. Reference scan across `v2/src`, `v2/bin`, `v2/scripts`, and `v2/docs` found no package-wired invocation path for those files.
+4. Supported startup path is documented and wired via CLI command flow:
+   - `claude-flow mcp start`
+
+## Classification
+
+- `server-with-wrapper.ts`: `DEPRECATE`
+- `server-wrapper-mode.ts`: `DEPRECATE`
+- `integrate-wrapper.ts`: `DEPRECATE`
+
+Rationale: they are not reachable through package entrypoints, but external manual invocation cannot be disproven.
+
+## Action Taken
+
+1. Added explicit runtime deprecation notices in all three files.
+2. Added `@deprecated` file-level annotations.
+3. Documented supported contract in `src/mcp/README.md`.
+
+## Removal Plan (Staged)
+
+1. Keep deprecated files through v2 patch line with warnings.
+2. Track for external usage signals (issues, release feedback, support tickets).
+3. Remove in the next major version if no usage evidence appears.

--- a/v2/docs/mcp-spec-2025-implementation-plan.md
+++ b/v2/docs/mcp-spec-2025-implementation-plan.md
@@ -1078,12 +1078,12 @@ jobs:
       - name: Publish to MCP Registry
         env:
           MCP_REGISTRY_API_KEY: ${{ secrets.MCP_REGISTRY_API_KEY }}
-        run: npm run registry:publish
+        run: echo "TODO: implement MCP registry publish client"
 
       - name: Update health check
         env:
           MCP_REGISTRY_API_KEY: ${{ secrets.MCP_REGISTRY_API_KEY }}
-        run: npm run registry:health
+        run: echo "TODO: implement MCP registry health check client"
 ```
 
 ---
@@ -1289,23 +1289,14 @@ describe('MCP Spec 2025 Compliance', () => {
 # Install dependencies
 npm install
 
-# Run async operation tests
-npm run test:async
+# Run available validation checks
+npm run typecheck
+npm run test:integration
+npm run test:coverage
 
-# Run registry integration tests
-npm run test:registry
-
-# Run full compliance suite
-npm run test:compliance
-
-# Publish to registry
-npm run registry:publish
-
-# Start server with async support
-npm run start:async
-
-# Monitor job queue
-npm run jobs:monitor
+# Development runtime and release flow
+npm run dev
+npm run publish:alpha
 ```
 
 ---

--- a/v2/package.json
+++ b/v2/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "preinstall": "node -e \"if(process.platform === 'win32' && process.env.npm_config_user_agent && process.env.npm_config_user_agent.includes('npm')) { console.warn('⚠️  Warning: On Windows, it is recommended to use pnpm to install this package to avoid potential native dependency build issues.'); console.warn('💡 Try: pnpm install or pnpx claude-flow@alpha'); }\"",
     "dev": "node --experimental-wasm-modules src/cli/main.ts",
-    "start": "node server.js",
+    "start": "node scripts/start-deprecated.js",
     "init:neural": "node scripts/init-neural.js",
     "init:goal": "node scripts/init-goal.js",
     "build": "npm run clean && npm run update-version && npm run build:esm && npm run build:cjs && npm run build:binary",
@@ -95,17 +95,8 @@
     "npm": ">=9.0.0"
   },
   "files": [
-    "cli.js",
+    "cli.mjs",
     "bin/claude-flow.js",
-    "bin/claude-flow",
-    "bin/claude-flow-dev",
-    "bin/claude-flow-pkg.js",
-    "bin/claude-flow-swarm",
-    "bin/claude-flow-swarm-background",
-    "bin/claude-flow-swarm-bg",
-    "bin/claude-flow-swarm-monitor",
-    "bin/claude-flow-swarm-ui",
-    "dist/",
     "src/",
     ".claude/",
     "docs/",
@@ -114,7 +105,7 @@
     "README.md",
     "LICENSE",
     "CHANGELOG.md",
-    "DOCKER_TEST_REPORT.md"
+    "DOCKER_TEST_CONFIRMATION.md"
   ],
   "dependencies": {
     "@anthropic-ai/claude-code": "^2.0.1",

--- a/v2/scripts/init-goal.js
+++ b/v2/scripts/init-goal.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { goalCommand } from '../src/cli/simple-commands/goal.js';
+
+function parseFlags(argv) {
+  const flags = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--force' || arg === '-f') {
+      flags.force = true;
+      continue;
+    }
+
+    if ((arg === '--target' || arg === '-t') && argv[i + 1]) {
+      flags.target = argv[i + 1];
+      i += 1;
+    }
+  }
+
+  return flags;
+}
+
+const flags = parseFlags(process.argv.slice(2));
+await goalCommand(['init'], flags);

--- a/v2/scripts/init-neural.js
+++ b/v2/scripts/init-neural.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { neuralCommand } from '../src/cli/simple-commands/neural.js';
+
+function parseFlags(argv) {
+  const flags = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--force' || arg === '-f') {
+      flags.force = true;
+      continue;
+    }
+
+    if ((arg === '--target' || arg === '-t') && argv[i + 1]) {
+      flags.target = argv[i + 1];
+      i += 1;
+    }
+  }
+
+  return flags;
+}
+
+const flags = parseFlags(process.argv.slice(2));
+await neuralCommand(['init'], flags);

--- a/v2/scripts/start-deprecated.js
+++ b/v2/scripts/start-deprecated.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+console.error(
+  '[claude-flow v2] `npm run start` is deprecated and no longer starts a runtime server.'
+);
+console.error(
+  'Use `claude-flow <command>` or `npx claude-flow <command>` for CLI workflows.'
+);
+process.exit(1);

--- a/v2/src/cli/commands/index.ts
+++ b/v2/src/cli/commands/index.ts
@@ -78,11 +78,8 @@ export function setupCommands(cli: CLI): void {
           },
         ],
         action: async (ctx: CommandContext) => {
-          const { initNeuralModule } = await import('../../scripts/init-neural.js');
-          await initNeuralModule({
-            force: ctx.flags.force as boolean,
-            targetDir: ctx.flags.target as string,
-          });
+          const { neuralCommand } = await import('../simple-commands/neural.js');
+          await neuralCommand(['init'], ctx.flags as Record<string, unknown>);
         },
       },
     ],
@@ -112,11 +109,8 @@ export function setupCommands(cli: CLI): void {
           },
         ],
         action: async (ctx: CommandContext) => {
-          const { initGoalModule } = await import('../../scripts/init-goal.js');
-          await initGoalModule({
-            force: ctx.flags.force as boolean,
-            targetDir: ctx.flags.target as string,
-          });
+          const { goalCommand } = await import('../simple-commands/goal.js');
+          await goalCommand(['init'], ctx.flags as Record<string, unknown>);
         },
       },
     ],
@@ -2888,4 +2882,3 @@ memory/sessions/
 ${new Date().toISOString()}
 `;
 }
-

--- a/v2/src/cli/simple-commands/verification-integration.js
+++ b/v2/src/cli/simple-commands/verification-integration.js
@@ -300,7 +300,7 @@ export class VerificationMiddleware {
 
   async checkTestCoverage() {
     try {
-      const { stdout } = await execAsync('npm run coverage 2>&1 || true');
+      const { stdout } = await execAsync('npm run test:coverage 2>&1 || true');
       const match = stdout.match(/(\d+(\.\d+)?)\s*%/);
       const percentage = match ? parseFloat(match[1]) : 0;
       return { percentage };

--- a/v2/src/mcp/README.md
+++ b/v2/src/mcp/README.md
@@ -13,6 +13,17 @@ The MCP implementation provides:
 - **Performance Monitoring**: Real-time metrics, alerting, and optimization suggestions
 - **Orchestration Integration**: Seamless integration with Claude-Flow components
 
+## Entrypoint Contract (v2)
+
+- **Supported CLI startup path:** `claude-flow mcp start`
+- **Package wiring:** `bin/claude-flow.js` -> CLI command router
+- **Deprecated internal wrapper entrypoints (not package-wired):**
+  - `src/mcp/server-with-wrapper.ts`
+  - `src/mcp/server-wrapper-mode.ts`
+  - `src/mcp/integrate-wrapper.ts`
+
+These wrapper files are kept for deprecate-first compatibility and are not part of the supported public startup contract.
+
 ## Architecture
 
 ```

--- a/v2/src/mcp/integrate-wrapper.ts
+++ b/v2/src/mcp/integrate-wrapper.ts
@@ -5,9 +5,13 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
 
 /**
- * Integration script that connects the Claude-Flow MCP wrapper
- * to the Claude Code MCP server
+ * @deprecated Internal integration helper for legacy MCP wrapper experiments.
+ * Not wired through the v2 package `bin`/`scripts` contract.
+ * Use `claude-flow mcp start` for supported startup.
  */
+const DEPRECATION_NOTICE =
+  '[DEPRECATED] src/mcp/integrate-wrapper.ts is an internal legacy integration entrypoint. Use `claude-flow mcp start` instead.';
+
 export class MCPIntegration {
   private claudeCodeClient?: Client;
   private wrapper: ClaudeCodeMCPWrapper;
@@ -51,6 +55,8 @@ export class MCPIntegration {
   }
 
   async start(): Promise<void> {
+    console.error(DEPRECATION_NOTICE);
+
     // Connect to Claude Code MCP
     await this.connectToClaudeCode();
 

--- a/v2/src/mcp/server-with-wrapper.ts
+++ b/v2/src/mcp/server-with-wrapper.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 /**
- * MCP Server entry point that uses the wrapper by default
+ * @deprecated Internal MCP wrapper entrypoint.
+ * Not wired through the v2 package `bin`/`scripts` contract.
+ * Use `claude-flow mcp start` for supported startup.
  */
 
 import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
@@ -9,7 +11,12 @@ import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
 const useLegacy =
   process.env.CLAUDE_FLOW_LEGACY_MCP === 'true' || process.argv.includes('--legacy');
 
+const DEPRECATION_NOTICE =
+  '[DEPRECATED] src/mcp/server-with-wrapper.ts is an internal legacy entrypoint. Use `claude-flow mcp start` instead.';
+
 async function main() {
+  console.error(DEPRECATION_NOTICE);
+
   if (useLegacy) {
     console.error('Starting Claude-Flow MCP in legacy mode...');
     // Dynamically import the old server to avoid circular dependencies

--- a/v2/src/mcp/server-wrapper-mode.ts
+++ b/v2/src/mcp/server-wrapper-mode.ts
@@ -2,7 +2,9 @@
 /**
  * Claude-Flow MCP Server - Wrapper Mode
  *
- * This version uses the Claude Code MCP wrapper approach instead of templates.
+ * @deprecated Internal MCP wrapper entrypoint.
+ * Not wired through the v2 package `bin`/`scripts` contract.
+ * Use `claude-flow mcp start` for supported startup.
  */
 
 import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
@@ -11,7 +13,12 @@ import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
 const isWrapperMode =
   process.env.CLAUDE_FLOW_WRAPPER_MODE === 'true' || process.argv.includes('--wrapper');
 
+const DEPRECATION_NOTICE =
+  '[DEPRECATED] src/mcp/server-wrapper-mode.ts is an internal legacy entrypoint. Use `claude-flow mcp start` instead.';
+
 async function main() {
+  console.error(DEPRECATION_NOTICE);
+
   if (isWrapperMode) {
     console.error('Starting Claude-Flow MCP in wrapper mode...');
     const wrapper = new ClaudeCodeMCPWrapper();


### PR DESCRIPTION
## Summary
- classify legacy MCP wrapper entrypoint files as deprecate-first (not delete)
- add explicit `@deprecated` markers and runtime notices in:
  - `v2/src/mcp/server-with-wrapper.ts`
  - `v2/src/mcp/server-wrapper-mode.ts`
  - `v2/src/mcp/integrate-wrapper.ts`
- document supported MCP startup contract (`claude-flow mcp start`) in:
  - `v2/src/mcp/README.md`
  - `v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md`
- record deprecation in `v2/CHANGELOG.md`

## Evidence
- `v2/package.json` bin wiring only exposes `bin/claude-flow.js`
- no script/bin wiring for wrapper entrypoint files
- wrapper-specific env flags only appear in the wrapper files and wrapper class messaging

## Validation
- wrapper wiring check:
  - `node -e "const pkg=require('./v2/package.json'); console.log(JSON.stringify({bin:pkg.bin,mcpScriptKeys:Object.keys(pkg.scripts).filter(k=>k.includes('mcp'))},null,2));"`
- deprecation markers check:
  - `rg -n "\[DEPRECATED\]|@deprecated|claude-flow mcp start" v2/src/mcp/server-with-wrapper.ts v2/src/mcp/server-wrapper-mode.ts v2/src/mcp/integrate-wrapper.ts v2/src/mcp/README.md v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md`
- `cd v2 && npm run typecheck -- --pretty false` (baseline repo has many pre-existing TS errors; no new wrapper-specific type errors observed)

Closes #51
