### PR TITLE
chore(v2): deprecate legacy MCP wrapper entrypoints

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `neural init` and `goal init` script entrypoints are restored with working `scripts/init-*.js` targets.
 - v2 CLI init command wiring now points at existing simple-command handlers for `neural init` and `goal init`.
 
+### Deprecated
+- Internal MCP wrapper entrypoints are now explicitly marked deprecated and are not part of the v2 public startup contract:
+  - `src/mcp/server-with-wrapper.ts`
+  - `src/mcp/server-wrapper-mode.ts`
+  - `src/mcp/integrate-wrapper.ts`
+- Supported MCP startup path remains: `claude-flow mcp start`.
+
 ## [2.7.35] - 2025-11-13
 
 ### Added

--- a/v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md
+++ b/v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md
@@ -1,0 +1,40 @@
+# MCP Wrapper Entrypoints Deprecation (v2)
+
+## Summary
+
+This note records the investigation outcome for legacy MCP wrapper entrypoints in v2 and defines the deprecate-first path.
+
+## Investigated Files
+
+- `src/mcp/server-with-wrapper.ts`
+- `src/mcp/server-wrapper-mode.ts`
+- `src/mcp/integrate-wrapper.ts`
+
+## Evidence
+
+1. `v2/package.json` exposes only one binary:
+   - `bin.claude-flow -> bin/claude-flow.js`
+2. `v2/package.json` has no script/bin wiring to the wrapper entrypoint files above.
+3. Reference scan across `v2/src`, `v2/bin`, `v2/scripts`, and `v2/docs` found no package-wired invocation path for those files.
+4. Supported startup path is documented and wired via CLI command flow:
+   - `claude-flow mcp start`
+
+## Classification
+
+- `server-with-wrapper.ts`: `DEPRECATE`
+- `server-wrapper-mode.ts`: `DEPRECATE`
+- `integrate-wrapper.ts`: `DEPRECATE`
+
+Rationale: they are not reachable through package entrypoints, but external manual invocation cannot be disproven.
+
+## Action Taken
+
+1. Added explicit runtime deprecation notices in all three files.
+2. Added `@deprecated` file-level annotations.
+3. Documented supported contract in `src/mcp/README.md`.
+
+## Removal Plan (Staged)
+
+1. Keep deprecated files through v2 patch line with warnings.
+2. Track for external usage signals (issues, release feedback, support tickets).
+3. Remove in the next major version if no usage evidence appears.

--- a/v2/src/mcp/README.md
+++ b/v2/src/mcp/README.md
@@ -13,6 +13,17 @@ The MCP implementation provides:
 - **Performance Monitoring**: Real-time metrics, alerting, and optimization suggestions
 - **Orchestration Integration**: Seamless integration with Claude-Flow components
 
+## Entrypoint Contract (v2)
+
+- **Supported CLI startup path:** `claude-flow mcp start`
+- **Package wiring:** `bin/claude-flow.js` -> CLI command router
+- **Deprecated internal wrapper entrypoints (not package-wired):**
+  - `src/mcp/server-with-wrapper.ts`
+  - `src/mcp/server-wrapper-mode.ts`
+  - `src/mcp/integrate-wrapper.ts`
+
+These wrapper files are kept for deprecate-first compatibility and are not part of the supported public startup contract.
+
 ## Architecture
 
 ```

--- a/v2/src/mcp/integrate-wrapper.ts
+++ b/v2/src/mcp/integrate-wrapper.ts
@@ -5,9 +5,13 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
 
 /**
- * Integration script that connects the Claude-Flow MCP wrapper
- * to the Claude Code MCP server
+ * @deprecated Internal integration helper for legacy MCP wrapper experiments.
+ * Not wired through the v2 package `bin`/`scripts` contract.
+ * Use `claude-flow mcp start` for supported startup.
  */
+const DEPRECATION_NOTICE =
+  '[DEPRECATED] src/mcp/integrate-wrapper.ts is an internal legacy integration entrypoint. Use `claude-flow mcp start` instead.';
+
 export class MCPIntegration {
   private claudeCodeClient?: Client;
   private wrapper: ClaudeCodeMCPWrapper;
@@ -51,6 +55,8 @@ export class MCPIntegration {
   }
 
   async start(): Promise<void> {
+    console.error(DEPRECATION_NOTICE);
+
     // Connect to Claude Code MCP
     await this.connectToClaudeCode();
 

--- a/v2/src/mcp/server-with-wrapper.ts
+++ b/v2/src/mcp/server-with-wrapper.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 /**
- * MCP Server entry point that uses the wrapper by default
+ * @deprecated Internal MCP wrapper entrypoint.
+ * Not wired through the v2 package `bin`/`scripts` contract.
+ * Use `claude-flow mcp start` for supported startup.
  */
 
 import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
@@ -9,7 +11,12 @@ import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
 const useLegacy =
   process.env.CLAUDE_FLOW_LEGACY_MCP === 'true' || process.argv.includes('--legacy');
 
+const DEPRECATION_NOTICE =
+  '[DEPRECATED] src/mcp/server-with-wrapper.ts is an internal legacy entrypoint. Use `claude-flow mcp start` instead.';
+
 async function main() {
+  console.error(DEPRECATION_NOTICE);
+
   if (useLegacy) {
     console.error('Starting Claude-Flow MCP in legacy mode...');
     // Dynamically import the old server to avoid circular dependencies

--- a/v2/src/mcp/server-wrapper-mode.ts
+++ b/v2/src/mcp/server-wrapper-mode.ts
@@ -2,7 +2,9 @@
 /**
  * Claude-Flow MCP Server - Wrapper Mode
  *
- * This version uses the Claude Code MCP wrapper approach instead of templates.
+ * @deprecated Internal MCP wrapper entrypoint.
+ * Not wired through the v2 package `bin`/`scripts` contract.
+ * Use `claude-flow mcp start` for supported startup.
  */
 
 import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
@@ -11,7 +13,12 @@ import { ClaudeCodeMCPWrapper } from './claude-code-wrapper.js';
 const isWrapperMode =
   process.env.CLAUDE_FLOW_WRAPPER_MODE === 'true' || process.argv.includes('--wrapper');
 
+const DEPRECATION_NOTICE =
+  '[DEPRECATED] src/mcp/server-wrapper-mode.ts is an internal legacy entrypoint. Use `claude-flow mcp start` instead.';
+
 async function main() {
+  console.error(DEPRECATION_NOTICE);
+
   if (isWrapperMode) {
     console.error('Starting Claude-Flow MCP in wrapper mode...');
     const wrapper = new ClaudeCodeMCPWrapper();


### PR DESCRIPTION
## Summary
- classify legacy MCP wrapper entrypoint files as deprecate-first (not delete)
- add explicit `@deprecated` markers and runtime notices in:
  - `v2/src/mcp/server-with-wrapper.ts`
  - `v2/src/mcp/server-wrapper-mode.ts`
  - `v2/src/mcp/integrate-wrapper.ts`
- document supported MCP startup contract (`claude-flow mcp start`) in:
  - `v2/src/mcp/README.md`
  - `v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md`
- record deprecation in `v2/CHANGELOG.md`

## Evidence
- `v2/package.json` bin wiring only exposes `bin/claude-flow.js`
- no script/bin wiring for wrapper entrypoint files
- wrapper-specific env flags only appear in wrapper files and wrapper class messaging

## Validation
- wrapper wiring check:
  - `node -e "const pkg=require('./v2/package.json'); console.log(JSON.stringify({bin:pkg.bin,mcpScriptKeys:Object.keys(pkg.scripts).filter(k=>k.includes('mcp'))},null,2));"`
- deprecation markers check:
  - `rg -n "\[DEPRECATED\]|@deprecated|claude-flow mcp start" v2/src/mcp/server-with-wrapper.ts v2/src/mcp/server-wrapper-mode.ts v2/src/mcp/integrate-wrapper.ts v2/src/mcp/README.md v2/docs/MCP_WRAPPER_ENTRYPOINTS_DEPRECATION.md`
- `cd v2 && npm run typecheck -- --pretty false` (baseline repo has many pre-existing TS errors)

Closes #51
